### PR TITLE
ci: set up caches in ci, and small fixes to readme

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: New Features 🎉
+      labels:
+        - feature
+    - title: Fixes 🔧
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,15 +17,31 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.13"
+
       - name: Install just
         run: |
           sudo apt update
           sudo snap install --edge --classic just
-      - name: Install dependencies
+
+      - name: Set up Poetry
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          poetry install
+
+      - name: Cache Poetry virtualenv and dependencies
+        id: cache-poetry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.virtualenvs
+            .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}
+
+      - name: Install dependencies
+        run: poetry install
 
       - name: Lint
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,70 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  push_to_pypi:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  push_to_docker_hub:
+    needs: push_to_pypi
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: elementsinteractive/lgtm-ai
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  release_notes:
+    runs-on: ubuntu-latest
+    needs: push_to_docker_hub
+    steps:
+      - uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,32 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install just
         run: |
           sudo apt update
           sudo snap install --edge --classic just
-      - name: Install dependencies
+
+      - name: Set up Poetry
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          poetry install
+
+      - name: Cache Poetry virtualenv and dependencies
+        id: cache-poetry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.virtualenvs
+            .venv
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: poetry install
 
       - name: Test with pytest
         run: |
-          just test
+          just test-all

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Elements
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ lgtm-ai is your AI-powered code review companion. It automates code reviews usin
 - [Quick Usage](#quick-usage)
   - [Review](#review)
   - [Reviewer Guide](#reviewer-guide)
+- [Installation](#installation)
 - [How it works](#how-it-works)
   - [Code Repository Service Support](#code-repository-service-support)
   - [Supported AI models](#supported-ai-models)
@@ -25,10 +26,10 @@ lgtm-ai is your AI-powered code review companion. It automates code reviews usin
   - [CI/CD Integration](#cicd-integration)
   - [Configuration](#configuration)
     - [Configuration file](#configuration-file)
-- [Installation](#installation)
-- [Running the project](#running-the-project)
-- [Managing requirements](#managing-requirements)
 - [Contributing](#contributing)
+  - [Running the project](#running-the-project)
+  - [Managing requirements](#managing-requirements)
+  - [Commit messages](#commit-messages)
 - [Contributors ✨](#contributors-)
 
 
@@ -65,11 +66,23 @@ This will generate a **reviewer guide** like this one:
 
 <img src="./assets/reviewer-guide.png" alt="lgtm-review-guide" height="250"/>
 
+## Installation
+
+```sh
+pip install lgtm-ai
+```
+
+Or you can use the official Docker image:
+
+```sh
+docker pull elementsinteractive/lgtm-ai
+```
+
 ## How it works
 
-lgtm reads the given pull request and feeds it to several AI agents to generate a code review. The philosophy of lgtm is to keep the models out of the picture and totally configurable, so that you can choose which model to use based on pricing, security, data privacy, or whatever is important to you.
+lgtm reads the given pull request and feeds it to several AI agents to generate a code review or a reviewer guide. The philosophy of lgtm is to keep the models out of the picture and totally configurable, so that you can choose which model to use based on pricing, security, data privacy, or whatever is important to you.
 
-If instructed (with the option `--publish`), lgtm will publish the review to the pull request page as comments. The review will also be displayed in the terminal.
+If instructed (with the option `--publish`), lgtm will publish the review or guide to the pull request page as comments.
 
 ### Code Repository Service Support
 
@@ -241,6 +254,7 @@ lgtm uses a `.toml` file to configure how it works. It will autodetect a `lgtm.t
 - **publish**: If `true`, it will post the review as comments on the PR page.
 - **ai_api_key**: API key to call the selected AI model. Can be given as a CLI argument, or as an environment variable (`LGTM_AI_API_KEY`).
 - **git_api_key**: API key to post the review in the source system of the PR. Can be given as a CLI argument, or as an environment variable (`LGTM_GIT_API_KEY`).
+- **ai_retries**: How many times to retry calls to the LLM when they do not succeed. By default, this is set to 1 (no retries at all).
 
 **Example `lgtm.toml`:**
 
@@ -261,13 +275,9 @@ When it comes to preference for selecting options, lgtm follows this preference 
   `CLI options` > `lgtm.toml` > `pyproject.toml`
 
 
-## Installation
+## Contributing
 
-```sh
-pip install lgtm-ai
-```
-
-## Running the project
+### Running the project
 
 This project uses [`just`](https://github.com/casey/just) recipes to do all the basic operations (testing the package, formatting the code, etc.).
 
@@ -311,7 +321,7 @@ just t tests/test_dummy.py
 just t -k test_dummy -vv
 ```
 
-## Managing requirements
+### Managing requirements
 
 `poetry` is the tool we use for managing requirements in this project. The generated virtual environment is kept within the directory of the project (in a directory named `.venv`), thanks to the option `POETRY_VIRTUALENVS_IN_PROJECT=1`. Refer to the [poetry documentation](https://python-poetry.org/docs/cli/) to see the list of available commands.
 
@@ -337,11 +347,12 @@ As a short summary:
 
         poetry lock --check
 
-## Contributing
+### Commit messages
+
 In this project we enforce [conventional commits](https://www.conventionalcommits.org) guidelines for commit messages. The usage of [commitizen](https://commitizen-tools.github.io/commitizen/) is recommended, but not required. Story numbers (JIRA, etc.) must go in the scope section of the commit message. Example message:
 
 ```
-feat(JIRA-XXX): add new feature x
+feat(#<issue-number>): add new feature x
 ```
 
 Merge requests must be approved before they can be merged to the `main` branch, and all the steps in the `ci` pipeline must pass.
@@ -352,6 +363,8 @@ configuring pre-commit to execute some of them can be beneficial to reduce late 
 ```sh
 just pre-commit
 ```
+
+Feel free to create [GitHub Issues](https://github.com/elementsinteractive/lgtm-ai/issues) for any feature request, bug, or suggestion!
 
 ## Contributors ✨
 


### PR DESCRIPTION
Now we cache the venv and poetry files of dependencies for each run of lint and test.

Re-run the lint job, and it did hit the cache:

<img width="862" alt="image" src="https://github.com/user-attachments/assets/296ab135-1241-42b3-9ef9-13a9aaec3b8f" />
