### PR TITLE
ci: remove unnecessary cli opts for lgtm workflow

### DIFF
--- a/.github/workflows/lgtm.yml
+++ b/.github/workflows/lgtm.yml
@@ -48,6 +48,4 @@ jobs:
           --pr-url "https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}" \
           --git-api-key "${{ secrets.GITHUB_TOKEN }}" \
           --ai-api-key "${{ secrets.AI_API_TOKEN }}" \
-          --model "gemini-2.5-pro-preview-05-06" \
-          --publish \
           -vv


### PR DESCRIPTION
These cli opts are in our lgtm.toml, there is no need to have them here.