### PR TITLE
fix: cli error prevented users from selecting deepseek models

### DIFF
--- a/src/lgtm_ai/ai/schemas.py
+++ b/src/lgtm_ai/ai/schemas.py
@@ -21,7 +21,7 @@ ReviewRawScore = (
         "1", "2", "3", "4", "5"
     ]  # TODO(https://github.com/pydantic/pydantic-ai/issues/1691): Gemini returns strings and pydantic-ai errors out when using integers in response models
 )
-type DeepSeekModel = Literal[
+DeepSeekModel = Literal[
     "deepseek-chat",
     "deepseek-reasoner",
 ]


### PR DESCRIPTION
`get_args` (which we rely on to set the click allowed params) does not work with `type`!