### PR TITLE
feat(#19): add initial support for local LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-lgtm-ai is your AI-powered code review companion. It automates code reviews using your favorite LLMs and helps human reviewers with detailed, context-aware reviewer guides. Supports GitHub, GitLab, and major models including GPT-4, Claude, Gemini, and more.
+lgtm-ai is your AI-powered code review companion. It generates code reviews using your favorite LLMs and helps human reviewers with detailed, context-aware reviewer guides. Supports GitHub, GitLab, and major AI models including GPT-4, Claude, Gemini, and more.
 
 **Table of Contents**
 - [Quick Usage](#quick-usage)
@@ -246,9 +246,21 @@ To get an API key for DeepSeek, create one at [DeepSeek Platform](https://platfo
 
 </details>
 
+#### Local models
+
+You can run lgtm against a model available at a custom url (say, models running with [ollama](https://ollama.com) at http://localhost:11434/v1). These models need to be compatible with OpenAI. In that case, you can pass the option `--model-url` (and you can choose to skip the option `--ai-api-token`). Check out the [pydantic-ai documentation](https://ai.pydantic.dev/models/openai/#openai-responses-api) to see more information about how lgtm interacts with these models.
+
+```sh
+lgtm review \
+  --pr-url https://github.com/group/repo/pull/1 \
+  --model llama3.2 \
+  --model-url http://localhost:11434/v1 \
+  ...
+```
+
 ### CI/CD Integration
 
-lgtm is meant to be integrated into your CI/CD pipeline, so that PR authors can choose to request reviews by running the necessary pipeline step. 
+lgtm is meant to be integrated into your CI/CD pipeline, so that PR authors can choose to request reviews by running the necessary pipeline step.
 
 For GitLab, you can use this .gitlab-ci.yml step as inspiration:
 
@@ -279,13 +291,14 @@ You can customize how lgtm works by passing cli arguments to it on invocation, o
 lgtm uses a `.toml` file to configure how it works. It will autodetect a `lgtm.toml` file in the current directory, or you can pass a specific file path with the CLI option `--config <path>`. These are the available options at the moment:
 
 - **technologies**: You can specify, as a list of free strings, which technologies lgtm specializes in. This can be helpful for directing the reviewer towards specific technologies. By default, lgtm won't assume any technology and will just review the PR considering itself an "expert" in it.
-- **categories**: lgtm will, by default, evaluate several areas of the given PR (`Quality`, `Correctness`, `Testing`, and `Security`). You can choose any subset of these (e.g.: if you are only interested in `Correctness`, you can configure `categories` so that lgtm does not evaluate the other missing areas). 
+- **categories**: lgtm will, by default, evaluate several areas of the given PR (`Quality`, `Correctness`, `Testing`, and `Security`). You can choose any subset of these (e.g.: if you are only interested in `Correctness`, you can configure `categories` so that lgtm does not evaluate the other missing areas).
 - **model**: Choose which AI model you want lgtm to use.
+- **model_url**: When not using one of the specific supported models from the providers mentioned above, you can pass a custom url where the model is deployed.
 - **exclude**: Instruct lgtm to ignore certain files. This is important to reduce noise in reviews, but also to reduce the amount of tokens used for each review (and to avoid running into token limits). You can specify file patterns (`exclude = ["*.md", "package-lock.json"]`)
 - **silent**: Do not print the review in the terminal.
 - **publish**: If `true`, it will post the review as comments on the PR page.
 - **ai_api_key**: API key to call the selected AI model. Can be given as a CLI argument, or as an environment variable (`LGTM_AI_API_KEY`).
-- **git_api_key**: API key to post the review in the source system of the PR. Can be given as a CLI argument, or as an environment variable (`LGTM_GIT_API_KEY`).
+- **git_api_key**: API key to post the review in the source system of the PR. Can be given as a CLI argument, or as an environment variable (`LGTM_GIT_API_KEY`). This is required to not be empty if using a non-local model.
 - **ai_retries**: How many times to retry calls to the LLM when they do not succeed. By default, this is set to 1 (no retries at all).
 
 **Example `lgtm.toml`:**

--- a/src/lgtm_ai/ai/exceptions.py
+++ b/src/lgtm_ai/ai/exceptions.py
@@ -1,0 +1,17 @@
+import click
+
+
+class MissingModelUrl(click.BadParameter):  # not a LGTMException because we want click to handle it gracefully
+    """Exception raised when a custom AI model URL is required but not provided."""
+
+    def __init__(self, model_name: str) -> None:
+        msg = f"Custom model '{model_name}' requires --model-url to be provided"
+        super().__init__(msg)
+
+
+class MissingAIAPIKey(click.BadParameter):
+    """Exception raised when an AI API key is required but not provided."""
+
+    def __init__(self, model_name: str) -> None:
+        msg = f"Model '{model_name}' requires an AI API key to be provided"
+        super().__init__(msg)

--- a/src/lgtm_ai/ai/schemas.py
+++ b/src/lgtm_ai/ai/schemas.py
@@ -21,7 +21,7 @@ ReviewRawScore = (
         "1", "2", "3", "4", "5"
     ]  # TODO(https://github.com/pydantic/pydantic-ai/issues/1691): Gemini returns strings and pydantic-ai errors out when using integers in response models
 )
-type DeepSeekModel = Literal[
+DeepSeekModel = Literal[
     "deepseek-chat",
     "deepseek-reasoner",
 ]
@@ -43,8 +43,16 @@ SupportedGeminiModel = Literal[
     "gemini-2.5-pro-preview-05-06",
 ]
 
+LocalAIModel = str
+"""Users may use any model name in their local AI server, so we just allow any string."""
+
 SupportedAIModels = (
-    ChatModel | SupportedGeminiModel | LatestAnthropicModelNames | LatestMistralModelNames | DeepSeekModel
+    ChatModel
+    | SupportedGeminiModel
+    | LatestAnthropicModelNames
+    | LatestMistralModelNames
+    | DeepSeekModel
+    | LocalAIModel
 )
 """Type of all supported AI models in lgtm."""
 
@@ -54,8 +62,8 @@ SupportedAIModelsList: Final[tuple[SupportedAIModels, ...]] = (
     + get_args(LatestAnthropicModelNames)
     + get_args(LatestMistralModelNames)
     + get_args(DeepSeekModel)
-)  # Keep in sync with SupportedAIModels
-"""Tuple of all supported AI models in lgtm."""
+)  # Keep in sync with SupportedAIModels except for LocalAIModel
+"""Tuple of all known supported AI models in lgtm."""
 
 
 SCORE_MAP: Final[dict[ReviewRawScore, ReviewScore]] = {

--- a/src/lgtm_ai/base/exceptions.py
+++ b/src/lgtm_ai/base/exceptions.py
@@ -17,8 +17,3 @@ class NothingToReviewError(LGTMException):
     def __init__(self, exclude: tuple[str, ...] | None = None) -> None:
         exclude = exclude or ()
         super().__init__(f"Nothing to review after excluding file patterns {', '.join(exclude)}.")
-
-
-class IncorrectAIModelError(LGTMException):
-    def __init__(self, model: str) -> None:
-        super().__init__(f"Incorrect AI model name: {model}.")

--- a/src/lgtm_ai/config/handler.py
+++ b/src/lgtm_ai/config/handler.py
@@ -26,6 +26,7 @@ class PartialConfig(BaseModel):
     """
 
     model: SupportedAIModels | None = None
+    model_url: str | None = None
     technologies: tuple[str, ...] | None = None
     categories: tuple[CommentCategory, ...] | None = None
     exclude: tuple[str, ...] | None = None
@@ -46,6 +47,9 @@ class ResolvedConfig(BaseModel):
 
     model: SupportedAIModels = DEFAULT_AI_MODEL
     """AI model to use for the review."""
+
+    model_url: str | None = None
+    """URL of the AI model to use for the review, if applicable."""
 
     technologies: tuple[str, ...] = ()
     """Technologies the reviewer is an expert in."""
@@ -116,6 +120,7 @@ class ConfigHandler:
         try:
             return PartialConfig(
                 model=config_data.get("model", None),
+                model_url=config_data.get("model_url", None),
                 technologies=config_data.get("technologies", None),
                 categories=config_data.get("categories", None),
                 exclude=config_data.get("exclude", None),
@@ -172,6 +177,7 @@ class ConfigHandler:
             technologies=self.cli_args.technologies or None,
             categories=self.cli_args.categories or None,
             model=self.cli_args.model or None,
+            model_url=self.cli_args.model_url or None,
             exclude=self.cli_args.exclude or None,
             ai_api_key=self.cli_args.ai_api_key or None,
             git_api_key=self.cli_args.git_api_key or None,
@@ -213,11 +219,14 @@ class ConfigHandler:
                     default=DEFAULT_AI_MODEL,
                 ),
             ),
+            model_url=from_cli.model_url or from_file.model_url,
             publish=from_cli.publish or from_file.publish,
             silent=from_cli.silent or from_file.silent,
             ai_retries=from_cli.ai_retries or from_file.ai_retries,
             git_api_key=self.resolver.resolve_string_field("git_api_key", from_cli=from_cli, from_env=from_env),
-            ai_api_key=self.resolver.resolve_string_field("ai_api_key", from_cli=from_cli, from_env=from_env),
+            ai_api_key=self.resolver.resolve_string_field(
+                "ai_api_key", from_cli=from_cli, from_env=from_env, required=False, default=""
+            ),
         )
         logger.debug("Resolved config: %s", resolved)
         return resolved

--- a/tests/ai/test_utils.py
+++ b/tests/ai/test_utils.py
@@ -3,21 +3,26 @@ from typing import Any
 
 import pytest
 from lgtm_ai.ai.agent import get_ai_model
-from lgtm_ai.base.exceptions import IncorrectAIModelError
+from lgtm_ai.ai.exceptions import MissingAIAPIKey, MissingModelUrl
 from pydantic_ai.models.gemini import GeminiModel
 from pydantic_ai.models.openai import OpenAIModel
 
 
 @pytest.mark.parametrize(
-    ("model", "expected_type", "expectation"),
+    ("model", "model_url", "ai_api_key", "expected_type", "expectation"),
     [
-        ("gpt-4", OpenAIModel, does_not_raise()),
-        ("gemini-1.5-flash", GeminiModel, does_not_raise()),
-        ("does-not-exist", None, pytest.raises(IncorrectAIModelError)),
+        ("gpt-4", None, "fake_api_key", OpenAIModel, does_not_raise()),
+        ("gemini-1.5-flash", None, "fake_api_key", GeminiModel, does_not_raise()),
+        ("does-not-exist", None, "fake_api_key", None, pytest.raises(MissingModelUrl)),
+        ("does-not-exist", "http://localhost:1234", "fake_api_key", OpenAIModel, does_not_raise()),
+        # We allow custom models with a URL but no API key
+        ("does-not-exist", "http://localhost:1234", "", OpenAIModel, does_not_raise()),
+        # We don't allow known models without an API key
+        ("gpt-4.1", "http://localhost:1234", "", OpenAIModel, pytest.raises(MissingAIAPIKey)),
     ],
 )
-def test_get_ai_model(model: str, expected_type: Any, expectation: Any) -> None:
+def test_get_ai_model(model: str, model_url: str | None, ai_api_key: str, expected_type: Any, expectation: Any) -> None:
     with expectation:
-        ai_model = get_ai_model(model, "fake_api_key")  # type: ignore[arg-type]
+        ai_model = get_ai_model(model, ai_api_key, model_url=model_url)
         assert isinstance(ai_model, expected_type)
         assert ai_model.model_name == model

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -53,7 +53,7 @@ def toml_with_invalid_config_field(tmp_path: Path) -> Iterator[str]:
     invalid_toml = tmp_path / "invalid.toml"
     data = """
     technologies = "foo"
-    model = "non-existing"
+    categories = ["bar"]
     """
     with create_tmp_file(invalid_toml, data) as tmp_file:
         yield tmp_file

--- a/tests/config/test_handler.py
+++ b/tests/config/test_handler.py
@@ -183,8 +183,7 @@ def test_incorrect_config_field_raises(toml_with_invalid_config_field: str) -> N
 
     error = exc.value
     assert "Invalid config file" in error.message
-    assert "'model': Input should be 'gpt-4.1'" in error.message
-    assert "'model': Input should be 'gemini-1.5-flash'" in error.message
+    assert "'categories': Input should be 'Correctness', 'Quality', 'Testing' or 'Security'" in error.message
     assert "'technologies': Input should be a valid tuple" in error.message
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -6,7 +6,7 @@ from unittest import mock
 import click
 import pytest
 from lgtm_ai.base.schemas import PRUrl
-from lgtm_ai.validators import parse_pr_url
+from lgtm_ai.validators import parse_pr_url, validate_model_url
 
 
 @pytest.mark.parametrize(
@@ -43,3 +43,19 @@ def test_parse_url_gitlab_valid() -> None:
         pr_number=1,
         source="gitlab",
     )
+
+
+@pytest.mark.parametrize(
+    ("url", "expectation"),
+    [
+        ("http://localhost:1234", does_not_raise()),
+        ("https://example.com:8080", does_not_raise()),
+        ("ftp://example.com", pytest.raises(click.BadParameter, match="http:// or https://")),
+        ("https://example.com", pytest.raises(click.BadParameter, match="must include a port")),
+        ("https://example.com:80", does_not_raise()),
+        ("https://example.com:288/path/to/model", does_not_raise()),
+    ],
+)
+def test_validate_model_url(url: str, expectation: AbstractContextManager[Any]) -> None:
+    with expectation:
+        validate_model_url(mock.Mock(), mock.Mock(), url)


### PR DESCRIPTION
Very initial and rough support for local OpenAI-compatible LLMs.

The idea is that we assume the url of the model to be that of the default provider (given the model name).
If the model name is instead custom (say, `llama2.3`, or `deepseek-rwhatever`), then we:
- Enforce `--model-url` to be provided: or we fail with a `click.BadParameter` error.
- Use the OpenAI provider with the provided `model-url` as `base_url`.

If `--model-url` is given for a known model (say, gpt-4.1), we ignore it.

This implementation is not ideal, because it relies on model names never being the same between local LLMs and externally provided LLMs. However, this was simple to do, and it covers many use cases. I'd be happy to discuss alternatives; for the future, or if you think this API is a no-go then for now!


I also added a couple of exceptions I faced running deepseek and llama locally.


🚨Notice I could not test this for real! The farther I got was to run deepsek-r1 and having a 400 error because that model is not supported by pydantic-ai (because pydantic-ai uses tools!). Better models that support tools break my computer 🙃 . Given that deepseek was returning understandable 400 errors like that, I think this _should_ work. But you never know until you try, of course!

closes #19 

