### PR TITLE
fix: allow any name given a --model-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ lgtm-ai is your AI-powered code review companion. It generates code reviews usin
     - [Anthropic's Claude](#anthropics-claude)
     - [Mistral AI](#mistral-ai)
     - [DeepSeek](#deepseek)
+    - [Local models](#local-models)
   - [CI/CD Integration](#cicd-integration)
   - [Configuration](#configuration)
     - [Configuration file](#configuration-file)
@@ -248,7 +249,7 @@ To get an API key for DeepSeek, create one at [DeepSeek Platform](https://platfo
 
 #### Local models
 
-You can run lgtm against a model available at a custom url (say, models running with [ollama](https://ollama.com) at http://localhost:11434/v1). These models need to be compatible with OpenAI. In that case, you can pass the option `--model-url` (and you can choose to skip the option `--ai-api-token`). Check out the [pydantic-ai documentation](https://ai.pydantic.dev/models/openai/#openai-responses-api) to see more information about how lgtm interacts with these models.
+You can run lgtm against a model available at a custom url (say, models running with [ollama](https://ollama.com) at http://localhost:11434/v1). These models need to be compatible with OpenAI. In that case, you need to pass the option `--model-url` (and you can choose to skip the option `--ai-api-token`). Check out the [pydantic-ai documentation](https://ai.pydantic.dev/models/openai/#openai-responses-api) to see more information about how lgtm interacts with these models.
 
 ```sh
 lgtm review \

--- a/src/lgtm_ai/ai/agent.py
+++ b/src/lgtm_ai/ai/agent.py
@@ -46,6 +46,10 @@ def get_ai_model(model_name: SupportedAIModels | str, api_key: str, model_url: s
     def _is_deepseek_model(model_name: SupportedAIModels) -> TypeGuard[DeepSeekModel]:
         return model_name in get_args(DeepSeekModel)
 
+    if model_url:
+        logger.info("Using model '%s' via custom OpenAI-compatible endpoint: %s", model_name, model_url)
+        return OpenAIModel(model_name=model_name, provider=OpenAIProvider(api_key=api_key, base_url=model_url))
+
     if model_name in SupportedAIModelsList and not api_key:
         raise MissingAIAPIKey(model_name=model_name)
 
@@ -60,12 +64,8 @@ def get_ai_model(model_name: SupportedAIModels | str, api_key: str, model_url: s
     elif _is_deepseek_model(model_name):
         return OpenAIModel(model_name=model_name, provider=DeepSeekProvider(api_key=api_key))
     else:
-        if not model_url:
-            raise MissingModelUrl(model_name=model_name)
-
-        # We only support OpenAI-compatible models with custom URLs for now.
-        logger.info("Using custom AI model: %s, available at: %s", model_name, model_url)
-        return OpenAIModel(model_name=model_name, provider=OpenAIProvider(api_key=api_key, base_url=model_url))
+        # Not known models but no custom URL was provided, so we raise an error
+        raise MissingModelUrl(model_name=model_name)
 
 
 def get_reviewer_agent_with_settings(

--- a/tests/ai/test_utils.py
+++ b/tests/ai/test_utils.py
@@ -18,7 +18,9 @@ from pydantic_ai.models.openai import OpenAIModel
         # We allow custom models with a URL but no API key
         ("does-not-exist", "http://localhost:1234", "", OpenAIModel, does_not_raise()),
         # We don't allow known models without an API key
-        ("gpt-4.1", "http://localhost:1234", "", OpenAIModel, pytest.raises(MissingAIAPIKey)),
+        ("gpt-4.1", None, "", OpenAIModel, pytest.raises(MissingAIAPIKey)),
+        # If one provides a known model, but with a custom URL, we create an OpenAIModel no matter the model name
+        ("gemini-2.5-pro-preview-05-06", "http://i-cloned-gemini.com:123", "", OpenAIModel, does_not_raise()),
     ],
 )
 def test_get_ai_model(model: str, model_url: str | None, ai_api_key: str, expected_type: Any, expectation: Any) -> None:


### PR DESCRIPTION
I thought a bit more about it, and it did not sit well with me that we don't allow a custom url for a known model name.

So instead, in this PR I changed the implementation in a way such that:
- If a user sets a `--model-url`, we assume we know what they are doing, and we are just going to try to call the given model there.
- If no `--model-url` is provided, then we are going to try to match the name; and if no name of model matches with our list of known models, we will raise an error.

This allows one to run DeepSeek models deployed in Azure, for instance.