### PR TITLE
fix(#28): harmonize github and gitlab implementations for getting context

### DIFF
--- a/src/lgtm_ai/ai/prompts.py
+++ b/src/lgtm_ai/ai/prompts.py
@@ -54,7 +54,7 @@ You will receive:
             ],
         }}
         ```
-- The contents of each of the changed files in the source (PR) branch. This should help you to understand the context of the PR.
+- The contents of each of the changed files in the source (PR) branch or the target branch. This should help you to understand the context of the PR.
 
 You should make two types of comments:
 - A summary comment, explaining what the overall quality of the code is, if there are any major issues, and a summary of the changes you require the author to make.
@@ -124,7 +124,7 @@ You are an AI agent that assists software developers in reviewing code changes b
 You will receive:
 - Metadata of a Pull Request (PR), including its title and description.
 - A git diff that shows the code changes introduced in the PR.
-- The full contents of the changed files in the source (PR) branch, which you can use to understand the surrounding code and intent.
+- The full contents of the changed files in the source (PR) branch or the target branch, which you can use to understand the surrounding code and intent.
 
 Your task is to generate a detailed yet concise reviewer guide to assist a human developer in conducting a thoughtful and thorough code review.
 

--- a/src/lgtm_ai/git_client/schemas.py
+++ b/src/lgtm_ai/git_client/schemas.py
@@ -1,5 +1,9 @@
+from typing import Literal
+
 from groq import BaseModel
 from lgtm_ai.git_parser.parser import DiffResult
+
+type ContextBranch = Literal["source", "target"]
 
 
 class PRDiff(BaseModel):
@@ -13,6 +17,7 @@ class PRDiff(BaseModel):
 class PRContextFileContents(BaseModel):
     file_path: str
     content: str
+    branch: ContextBranch = "source"
 
 
 class PRContext(BaseModel):
@@ -26,8 +31,8 @@ class PRContext(BaseModel):
     def __bool__(self) -> bool:
         return bool(self.file_contents)
 
-    def add_file(self, file_path: str, content: str) -> None:
-        self.file_contents.append(PRContextFileContents(file_path=file_path, content=content))
+    def add_file(self, file_path: str, content: str, branch: ContextBranch = "source") -> None:
+        self.file_contents.append(PRContextFileContents(file_path=file_path, content=content, branch=branch))
 
 
 class PRMetadata(BaseModel):

--- a/src/lgtm_ai/review/prompt_generators.py
+++ b/src/lgtm_ai/review/prompt_generators.py
@@ -65,7 +65,7 @@ class PromptGenerator:
             return ""
 
         content = self._indent(file_context.content)
-        return f"    ```{file_context.file_path}\n{content}\n    ```"
+        return f"    ```{file_context.file_path}, branch={file_context.branch}\n{content}\n    ```"
 
     def _pr_diff_prompt(self, pr_diff: PRDiff) -> str:
         return f"PR Diff:\n    ```\n{self._indent(self._serialize_pr_diff(pr_diff))}\n    ```"

--- a/tests/git_client/test_github.py
+++ b/tests/git_client/test_github.py
@@ -284,7 +284,8 @@ def test_get_context_one_file_missing() -> None:
 
     m_repo.get_contents.side_effect = [
         mock.Mock(decoded_content=b"lorem ipsum dolor sit amet"),
-        github.GithubException(status=404, message="Not Found"),
+        github.GithubException(status=404, message="Not Found"),  # source branch
+        github.GithubException(status=404, message="Not Found"),  # target branch
     ]
     context = client.get_context(
         PRUrl(full_url="https://foo", repo_path="path", pr_number=1, source="github"),

--- a/tests/git_client/test_gitlab.py
+++ b/tests/git_client/test_gitlab.py
@@ -407,7 +407,7 @@ def test_get_context_deleted_file() -> None:
 
     assert context == PRContext(
         file_contents=[
-            PRContextFileContents(file_path="missing.py", content="surprise"),
+            PRContextFileContents(file_path="missing.py", content="surprise", branch="target"),
         ]
     )
     calls = m_project.files.get.call_args_list

--- a/tests/review/test_reviewer.py
+++ b/tests/review/test_reviewer.py
@@ -82,11 +82,11 @@ def test_get_review_from_url_valid() -> None:
             {json.dumps([diff.model_dump() for diff in MOCK_DIFF])}
             ```
         Context:
-            ```file1.txt
+            ```file1.txt, branch=source
             contents-of-file-1-context
             ```
 
-            ```file2.txt
+            ```file2.txt, branch=source
             contents-of-file-2-context
             ```
         """


### PR DESCRIPTION
There was no parity between GitHub and GitLab when getting context files, and the branch was not correctly communicated in the prompt (see issue description).

closes #28 