### PR TITLE
feat(#52): add support for new gemini-pro-06-05

### DIFF
--- a/ai_assessments/2025-06-12-newgem/review-pr-PR-1-trivial-1.md
+++ b/ai_assessments/2025-06-12-newgem/review-pr-PR-1-trivial-1.md
@@ -1,0 +1,48 @@
+# Review for PR: PR-1-trivial
+
+> Sample 1
+
+> Using model: gemini-2.5-pro-preview-06-05
+
+
+## 🦉 lgtm Review
+
+> **Score:** LGTM 👍
+
+### 🔍 Summary
+
+The PR consists of two changes: updating the cruft commit hash and fixing the pre-commit configuration. The changes in `.pre-commit-config.yaml` correct invalid stage names (`push` to `pre-push` and `commit` to `pre-commit`), which improves the repository's developer tooling setup. The changes are correct and the PR quality is excellent.
+
+<details><summary>More information</summary>
+
+- **Id**: `241d2c718c544bf9bb3bc32788496e4d`
+- **Model**: `gemini-2.5-pro-preview-06-05`
+- **Created at**: `2025-06-12T08:37:05.908571+00:00`
+
+
+<details><summary>Usage summary</summary>
+
+<details><summary>Call 1</summary>
+
+- **Request count**: `1`
+- **Request tokens**: `2393`
+- **Response tokens**: `97`
+- **Total tokens**: `4584`
+</details>
+
+
+<details><summary>Call 2</summary>
+
+- **Request count**: `1`
+- **Request tokens**: `2104`
+- **Response tokens**: `97`
+- **Total tokens**: `3272`
+</details>
+
+**Total tokens**: `7856`
+</details>
+
+
+> See the [📚 lgtm-ai repository](https://github.com/elementsinteractive/lgtm-ai) for more information about lgtm.
+
+</details>

--- a/lgtm.toml
+++ b/lgtm.toml
@@ -1,7 +1,7 @@
 technologies = ["Python", "AI"]
 categories = ["Correctness", "Quality", "Testing", "Security"]
 exclude = ["*.md", "poetry.lock"]
-model = "gemini-2.5-pro-preview-05-06"
+model = "gemini-2.5-flash-preview-05-20"
 silent = false
 publish = true
 ai_retries = 2

--- a/src/lgtm_ai/ai/schemas.py
+++ b/src/lgtm_ai/ai/schemas.py
@@ -43,6 +43,7 @@ SupportedGeminiModel = Literal[
     "gemini-2.5-pro-preview-03-25",
     "gemini-2.5-pro-preview-05-06",
     "gemini-2.5-flash-preview-05-20",
+    "gemini-2.5-pro-preview-06-05",
 ]
 
 LocalAIModel = str


### PR DESCRIPTION
I could not run the full evaluation because this model takes 20+ minutes _**per review**_, compared to 10/20 seconds for gemini-pro-05-06

I found these threads, but so far nothing has really been acknowledged:
- https://discuss.ai.google.dev/t/gemini-2-5-pro-preview-06-05-extremely-slow/87953
- https://discuss.ai.google.dev/t/very-slow-response-time-on-the-new-2-5-pro-0605-model/87456


closes #52