### PR TITLE
fix: ensure that model name in summary is the **resolved** name without wildcards

### DIFF
--- a/src/lgtm_ai/review/guide.py
+++ b/src/lgtm_ai/review/guide.py
@@ -45,5 +45,5 @@ class ReviewGuideGenerator:
         return ReviewGuide(
             pr_diff=pr_diff,
             guide_response=raw_res.output,
-            metadata=PublishMetadata(model_name=self.config.model, usages=[raw_res.usage()]),
+            metadata=PublishMetadata(model_name=self.model.model_name, usages=[raw_res.usage()]),
         )

--- a/src/lgtm_ai/review/reviewer.py
+++ b/src/lgtm_ai/review/reviewer.py
@@ -95,5 +95,5 @@ class CodeReviewer:
         return Review(
             pr_diff=pr_diff,
             review_response=final_res.output,
-            metadata=PublishMetadata(model_name=self.config.model, usages=[initial_usage, final_usage]),
+            metadata=PublishMetadata(model_name=self.model.model_name, usages=[initial_usage, final_usage]),
         )

--- a/tests/review/test_guide.py
+++ b/tests/review/test_guide.py
@@ -27,7 +27,7 @@ def test_get_guide_from_url_valid() -> None:
     ):
         guide_generator = ReviewGuideGenerator(
             guide_agent=test_agent,
-            model=mock.Mock(spec=OpenAIModel),
+            model=mock.Mock(spec=OpenAIModel, model_name="gemini-2.0-flash"),
             git_client=MockGitClient(),
             config=ResolvedConfig(),
         )

--- a/tests/review/test_reviewer.py
+++ b/tests/review/test_reviewer.py
@@ -50,7 +50,7 @@ def test_get_review_from_url_valid() -> None:
         code_reviewer = CodeReviewer(
             reviewer_agent=test_agent,
             summarizing_agent=test_summary_agent,
-            model=mock.Mock(spec=OpenAIModel),
+            model=mock.Mock(spec=OpenAIModel, model_name=DEFAULT_AI_MODEL),
             git_client=MockGitClient(),
             config=ResolvedConfig(
                 additional_context=(
@@ -126,7 +126,7 @@ def test_get_review_adds_technologies_to_prompt() -> None:
         code_reviewer = CodeReviewer(
             reviewer_agent=test_agent,
             summarizing_agent=test_summary_agent,
-            model=mock.Mock(spec=OpenAIModel),
+            model=mock.Mock(spec=OpenAIModel, model_name=DEFAULT_AI_MODEL),
             git_client=MockGitClient(),
             config=ResolvedConfig(technologies=("COBOL", "FORTRAN", "ODIN")),
         )
@@ -159,7 +159,7 @@ def test_get_review_adds_categories_to_prompt() -> None:
         code_reviewer = CodeReviewer(
             reviewer_agent=test_agent,
             summarizing_agent=test_summary_agent,
-            model=mock.Mock(spec=OpenAIModel),
+            model=mock.Mock(spec=OpenAIModel, model_name=DEFAULT_AI_MODEL),
             git_client=MockGitClient(),
             config=ResolvedConfig(categories=("Correctness", "Quality")),
         )
@@ -185,7 +185,7 @@ def test_review_fails_if_all_files_are_excluded() -> None:
     code_reviewer = CodeReviewer(
         reviewer_agent=mock.Mock(),
         summarizing_agent=mock.Mock(),
-        model=mock.Mock(spec=OpenAIModel),
+        model=mock.Mock(spec=OpenAIModel, model_name=DEFAULT_AI_MODEL),
         git_client=MockGitClient(),
         config=ResolvedConfig(exclude=("*.txt",)),  # we exclude all txt files
     )
@@ -208,7 +208,7 @@ def test_file_is_excluded_from_prompt() -> None:
         code_reviewer = CodeReviewer(
             reviewer_agent=test_agent,
             summarizing_agent=test_summary_agent,
-            model=mock.Mock(spec=OpenAIModel),
+            model=mock.Mock(spec=OpenAIModel, model_name=DEFAULT_AI_MODEL),
             git_client=MockGitClient(),
             config=ResolvedConfig(exclude=("file2.txt",)),
         )
@@ -240,7 +240,7 @@ def test_errors_are_handled_on_reviewer_agent(raised_error: Exception, expected_
     code_reviewer = CodeReviewer(
         reviewer_agent=error_agent,
         summarizing_agent=mock.Mock(),
-        model=mock.Mock(spec=OpenAIModel),
+        model=mock.Mock(spec=OpenAIModel, model_name=DEFAULT_AI_MODEL),
         git_client=MockGitClient(),
         config=ResolvedConfig(),
     )


### PR DESCRIPTION
We were showing stuff like "gemini-flash-*" in the summary comment, when we actually want to show the **real** model resolved.