### PR TITLE
fix(#99): handle git diff errors when working with non-text files

### DIFF
--- a/src/lgtm_ai/git_parser/parser.py
+++ b/src/lgtm_ai/git_parser/parser.py
@@ -27,8 +27,11 @@ class DiffResult(BaseModel):
     modified_lines: list[ModifiedLine]
 
 
-def parse_diff_patch(metadata: DiffFileMetadata, diff_text: str) -> DiffResult:
+def parse_diff_patch(metadata: DiffFileMetadata, diff_text: object) -> DiffResult:
+    if not isinstance(diff_text, str):
+        raise GitDiffParseError("Diff text is not a string")
     lines = diff_text.strip().splitlines()
+
     modified_lines = []
 
     old_line_num = 0

--- a/tests/git_parser/test_parser.py
+++ b/tests/git_parser/test_parser.py
@@ -1,4 +1,5 @@
 import pytest
+from lgtm_ai.git_parser.exceptions import GitDiffParseError
 from lgtm_ai.git_parser.parser import DiffResult, parse_diff_patch
 from tests.git_parser.fixtures import (
     COMPLEX_DIFF_TEXT,
@@ -19,6 +20,11 @@ from tests.git_parser.fixtures import (
 )
 def test_parse_diff_patch(input_diff: str, expected: DiffResult) -> None:
     assert parse_diff_patch(DUMMY_METADATA, input_diff) == expected
+
+
+def test_parse_diff_patch_non_text_files() -> None:
+    with pytest.raises(GitDiffParseError, match="Diff text is not a string"):
+        parse_diff_patch(DUMMY_METADATA, diff_text=bytes(1234))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #99 