### PR TITLE
feat(#93): lgtm can now optionally use issues from GitLab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ mypy_path = "src"
 strict = true          # strict type checking.
 warn_no_return = false # allow functions without explicit return.
 pretty = true          # show error messages in a readable format.
+plugins = ['pydantic.mypy']
 
 [tool.twyn]
 allowlist = [

--- a/src/lgtm_ai/__main__.py
+++ b/src/lgtm_ai/__main__.py
@@ -13,7 +13,7 @@ from lgtm_ai.ai.agent import (
     get_summarizing_agent_with_settings,
 )
 from lgtm_ai.ai.schemas import AgentSettings, CommentCategory, SupportedAIModels, SupportedAIModelsList
-from lgtm_ai.base.schemas import IntOrNoLimit, OutputFormat, PRUrl
+from lgtm_ai.base.schemas import IntOrNoLimit, IssuesSource, OutputFormat, PRUrl
 from lgtm_ai.base.utils import git_source_supports_suggestions
 from lgtm_ai.config.constants import DEFAULT_INPUT_TOKEN_LIMIT
 from lgtm_ai.config.handler import ConfigHandler, PartialConfig
@@ -96,6 +96,21 @@ def _common_options[**P, T](func: Callable[P, T]) -> Callable[P, T]:
 
 @entry_point.command()
 @click.option(
+    "--issues-url",
+    type=click.STRING,
+    help="The URL of the issues page to retrieve additional context from.",
+)
+@click.option(
+    "--issues-source",
+    type=click.Choice([source.value for source in IssuesSource]),
+    help="The platform of the issues page.",
+)
+@click.option(
+    "--issues-regex",
+    type=click.STRING,
+    help="Regex to extract issue ID from the PR title and description.",
+)
+@click.option(
     "--technologies",
     multiple=True,
     help="List of technologies the reviewer is an expert in. If not provided, the reviewer will be an expert of all technologies in the given PR. Use it if you want to guide the reviewer to focus on specific technologies.",
@@ -123,6 +138,9 @@ def review(
     verbose: int,
     technologies: tuple[str, ...],
     categories: tuple[CommentCategory, ...],
+    issues_url: str | None,
+    issues_regex: str | None,
+    issues_source: IssuesSource | None,
 ) -> None:
     """Review a Pull Request using AI."""
     _set_logging_level(logger, verbose)
@@ -144,6 +162,9 @@ def review(
             silent=silent,
             ai_retries=ai_retries,
             ai_input_tokens_limit=ai_input_tokens_limit,
+            issues_url=issues_url,
+            issues_regex=issues_regex,
+            issues_source=issues_source,
         ),
         config_file=config,
     ).resolve_config()

--- a/src/lgtm_ai/ai/prompts.py
+++ b/src/lgtm_ai/ai/prompts.py
@@ -55,6 +55,7 @@ You will receive:
         }}
         ```
 - `Context`, which consists on the contents of each of the changed files in the source (PR) branch or the target branch. This should help you to understand the context of the PR.
+- Optionally, `User Story` that the PR is implementing, which will consist of a title and a description. You must evaluate whether the PR is correctly implementing the user story (in its totality or partially).
 - Optionally, `Additional context` that the author of the PR has provided, which may contain a prompt (to give you a hint on what to use it for), and some content.
 
 You should make two types of comments:

--- a/src/lgtm_ai/base/schemas.py
+++ b/src/lgtm_ai/base/schemas.py
@@ -11,6 +11,14 @@ class PRSource(StrEnum):
     gitlab = "gitlab"
 
 
+class IssuesSource(StrEnum):
+    gitlab = "gitlab"
+
+    @property
+    def is_git_platform(self) -> bool:
+        return self in {IssuesSource.gitlab}
+
+
 @dataclass(frozen=True, slots=True)
 class PRUrl:
     full_url: str

--- a/src/lgtm_ai/config/constants.py
+++ b/src/lgtm_ai/config/constants.py
@@ -2,3 +2,4 @@ from lgtm_ai.ai.schemas import SupportedAIModels
 
 DEFAULT_AI_MODEL: SupportedAIModels = "gemini-2.0-flash"
 DEFAULT_INPUT_TOKEN_LIMIT = 500000
+DEFAULT_ISSUE_REGEX = r"(?:refs?|closes?)[:\s]*((?:#\d+)|(?:#?[A-Z]+-\d+))|(?:fix|feat|docs|style|refactor|perf|test|build|ci)\((?:#(\d+)|#?([A-Z]+-\d+))\)!?:"

--- a/src/lgtm_ai/config/exceptions.py
+++ b/src/lgtm_ai/config/exceptions.py
@@ -1,4 +1,5 @@
 from lgtm_ai.base.exceptions import LGTMException
+from pydantic import ValidationError
 from pydantic_core import ErrorDetails
 
 
@@ -18,8 +19,28 @@ class InvalidConfigError(LGTMException):
         return self.message
 
     def _generate_message(self) -> str:
-        messages = [f"'{str(error['loc'][0])}': {error['msg']}" for error in self.errors]
+        messages = _extract_errors_from_validation_error(self.errors)
         return f"Invalid config file '{self.source}':\n" + "\n".join(messages)
 
 
+class InvalidOptionsError(LGTMException):
+    """Raised when options (no matter where they come from) are invalid."""
+
+    def __init__(self, err: ValidationError) -> None:
+        self.err = err
+        self.message = self._generate_message()
+
+    def __str__(self) -> str:
+        return self.message
+
+    def _generate_message(self) -> str:
+        messages = _extract_errors_from_validation_error(self.err)
+        return "Invalid options:\n" + "\n".join(messages)
+
+
 class MissingRequiredConfigError(LGTMException): ...
+
+
+def _extract_errors_from_validation_error(err: ValidationError | list[ErrorDetails]) -> list[str]:
+    errors = err.errors() if isinstance(err, ValidationError) else err
+    return [f"'{str(error['loc'][0])}': {error['msg']}" for error in errors]

--- a/src/lgtm_ai/config/validators.py
+++ b/src/lgtm_ai/config/validators.py
@@ -1,0 +1,13 @@
+import re
+
+
+def validate_regex(value: str | None) -> str | None:
+    if value is None:
+        return value
+
+    try:
+        re.compile(value)
+    except re.error as err:
+        raise ValueError(f"Invalid regex: {err}") from err
+    else:
+        return value

--- a/src/lgtm_ai/git_client/base.py
+++ b/src/lgtm_ai/git_client/base.py
@@ -2,7 +2,8 @@ from typing import Protocol
 
 from lgtm_ai.ai.schemas import Review, ReviewGuide
 from lgtm_ai.base.schemas import PRUrl
-from lgtm_ai.git_client.schemas import ContextBranch, PRDiff, PRMetadata
+from lgtm_ai.git_client.schemas import ContextBranch, IssueContent, PRDiff, PRMetadata
+from pydantic import HttpUrl
 
 
 class GitClient(Protocol):
@@ -16,6 +17,9 @@ class GitClient(Protocol):
 
     def get_pr_metadata(self, pr_url: PRUrl) -> PRMetadata:
         """Get metadata for the PR given its URL."""
+
+    def get_issue_content(self, issues_url: HttpUrl, issue_id: str) -> IssueContent | None:
+        """Fetch the content of an issue from its URL."""
 
     def publish_guide(self, pr_url: PRUrl, guide: ReviewGuide) -> None:
         """Publish a review guide to the PR."""

--- a/src/lgtm_ai/git_client/github.py
+++ b/src/lgtm_ai/git_client/github.py
@@ -22,6 +22,7 @@ from lgtm_ai.git_client.exceptions import (
 from lgtm_ai.git_client.schemas import ContextBranch, PRDiff, PRMetadata
 from lgtm_ai.git_parser.exceptions import GitDiffParseError
 from lgtm_ai.git_parser.parser import DiffFileMetadata, DiffResult, parse_diff_patch
+from pydantic import HttpUrl
 
 logger = logging.getLogger("lgtm.git")
 
@@ -103,6 +104,9 @@ class GitHubClient(GitClient):
             raise PullRequestMetadataError from err
 
         return PRMetadata(title=pr.title or "", description=pr.body or "")
+
+    def get_issue_content(self, issue_url: HttpUrl, issue_id: str) -> None:
+        raise NotImplementedError("GitHub issues are not yet supported")
 
     def publish_guide(self, pr_url: PRUrl, guide: ReviewGuide) -> None:
         pr = _get_pr(self.client, pr_url)

--- a/src/lgtm_ai/git_client/schemas.py
+++ b/src/lgtm_ai/git_client/schemas.py
@@ -17,3 +17,8 @@ class PRDiff(BaseModel):
 class PRMetadata(BaseModel):
     title: str
     description: str
+
+
+class IssueContent(BaseModel):
+    title: str
+    description: str

--- a/src/lgtm_ai/review/prompt_generators.py
+++ b/src/lgtm_ai/review/prompt_generators.py
@@ -8,7 +8,7 @@ from lgtm_ai.ai.schemas import AdditionalContext, ReviewResponse
 from lgtm_ai.base.exceptions import NothingToReviewError
 from lgtm_ai.base.utils import file_matches_any_pattern
 from lgtm_ai.config.handler import ResolvedConfig
-from lgtm_ai.git_client.schemas import PRDiff, PRMetadata
+from lgtm_ai.git_client.schemas import IssueContent, PRDiff, PRMetadata
 from lgtm_ai.review.schemas import PRCodeContext, PRContextFileContents
 
 logger = logging.getLogger("lgtm.ai")
@@ -28,7 +28,12 @@ class PromptGenerator:
         self._template_env = Environment(loader=FileSystemLoader(template_dir), autoescape=False)  # noqa: S701
 
     def generate_review_prompt(
-        self, *, pr_diff: PRDiff, context: PRCodeContext, additional_context: list[AdditionalContext] | None = None
+        self,
+        *,
+        pr_diff: PRDiff,
+        context: PRCodeContext,
+        additional_context: list[AdditionalContext] | None = None,
+        issue_context: IssueContent | None = None,
     ) -> str:
         """Generate the initial prompt for the AI model to review the PR.
 
@@ -39,6 +44,7 @@ class PromptGenerator:
             metadata=self.pr_metadata,
             diff=self._serialize_pr_diff(pr_diff),
             context=self._filter_context_based_on_exclusions(context.file_contents),
+            issue_context=issue_context,
             additional_context=additional_context,
         )
 

--- a/src/lgtm_ai/review/reviewer.py
+++ b/src/lgtm_ai/review/reviewer.py
@@ -90,9 +90,22 @@ class CodeReviewer:
             pr_url=pr_url,
             additional_context=self.config.additional_context,
         )
+        if self.config.issues_source and self.config.issues_url and self.config.issues_regex:
+            logger.info("Fetching issue context related to the PR")
+            issue_context = self.context_retriever.get_issues_context(
+                issues_source=self.config.issues_source,
+                issues_url=self.config.issues_url,
+                issues_regex=self.config.issues_regex,
+                pr_metadata=self.git_client.get_pr_metadata(pr_url),
+            )
+        else:
+            issue_context = None
 
         review_prompt = prompt_generator.generate_review_prompt(
-            pr_diff=pr_diff, context=context, additional_context=additional_context
+            pr_diff=pr_diff,
+            context=context,
+            additional_context=additional_context,
+            issue_context=issue_context,
         )
         logger.info("Running Reviewer agent on the PR diff")
         with handle_ai_exceptions():

--- a/src/lgtm_ai/review/templates/review_prompt.txt.j2
+++ b/src/lgtm_ai/review/templates/review_prompt.txt.j2
@@ -2,6 +2,12 @@ PR METADATA:
 - Title: {{ metadata.title }}
 - Description: {{ metadata.description }}
 
+{% if issue_context %}
+USER STORY:
+- Title: {{ issue_context.title }}
+- Description: {{ issue_context.description }}
+{% endif %}
+
 PR DIFF:
 ```
 {{ diff }}

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -98,6 +98,17 @@ def toml_with_invalid_config_field(tmp_path: Path) -> Iterator[str]:
 
 
 @pytest.fixture
+def toml_with_some_issues_configs(tmp_path: Path) -> Iterator[str]:
+    pyproject_toml = tmp_path / "lgtm.toml"
+    data = """
+    issues_source = "gitlab"
+    issues_regex = "some-regex"
+    """
+    with create_tmp_file(pyproject_toml, data) as tmp_file:
+        yield tmp_file
+
+
+@pytest.fixture
 def inject_env_secrets() -> Iterator[None]:
     # Backup a copy of the current environment
     original_env = copy.deepcopy(os.environ)

--- a/tests/review/utils.py
+++ b/tests/review/utils.py
@@ -3,8 +3,9 @@ from unittest import mock
 from lgtm_ai.ai.schemas import Review, ReviewGuide
 from lgtm_ai.base.schemas import PRUrl
 from lgtm_ai.git_client.base import GitClient
-from lgtm_ai.git_client.schemas import ContextBranch, PRDiff, PRMetadata
+from lgtm_ai.git_client.schemas import ContextBranch, IssueContent, PRDiff, PRMetadata
 from lgtm_ai.git_parser.parser import DiffFileMetadata, DiffResult, ModifiedLine
+from pydantic import HttpUrl
 from pydantic_ai.usage import RunUsage
 
 MOCK_USAGE = mock.MagicMock(
@@ -53,10 +54,13 @@ class MockGitClient(GitClient):
         return None
 
     def get_pr_metadata(self, pr_url: PRUrl) -> PRMetadata:
-        return PRMetadata(title="foo", description="bar")
+        return PRMetadata(title="feat(#288): a title", description="bar")
 
     def publish_guide(self, pr_url: PRUrl, guide: ReviewGuide) -> None:
         return None
+
+    def get_issue_content(self, issues_url: HttpUrl, issue_id: str) -> IssueContent | None:
+        return IssueContent(title="Issue title", description="Issue description")
 
     def get_file_contents(self, pr_url: PRUrl, file_path: str, branch_name: ContextBranch) -> str | None:
         return f"contents-of-{file_path}-context"


### PR DESCRIPTION
With this PR, we can now parse GitLab issues and provide them in the prompt.

lgtm extracts the relevant issue from the title+description using a user-configurable regex. We provide a sane default that works with how we mostly write our PR titles and descriptions (see tests for some examples).

We allow this whole process to fail: it is considered "extra context" and thus if for some reason it fails, lgtm continues with its review (with an error log).

There are some warts, which can be addressed in follow-up PRs:

- We extract a single issue, what if a PR closes several?
- We re-use the git client (with its credentials) to access the issues. What if a user wants to provide a gitlab issues url that is different from the repo AND the given `git-api-key` has no permissions for this? Since for Jira #94 we will need credentials, I will revisit this there, to have a holistic way of handling credentials for this.
- Parsing the url as soon as given in click had problems (namely, we have to parse both in click _and_ in the config handler). This made it very unergonomic. I will revisit this later.
- No evaluation of whether this makes for better reviews, or whether the prompt needs improving.
