### PR TITLE
feat(#92): add GitHub issues to prompt to the LLM

### DIFF
--- a/src/lgtm_ai/base/schemas.py
+++ b/src/lgtm_ai/base/schemas.py
@@ -12,11 +12,12 @@ class PRSource(StrEnum):
 
 
 class IssuesSource(StrEnum):
+    github = "github"
     gitlab = "gitlab"
 
     @property
     def is_git_platform(self) -> bool:
-        return self in {IssuesSource.gitlab}
+        return self in {IssuesSource.gitlab, IssuesSource.github}
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/lgtm_ai/git_client/base.py
+++ b/src/lgtm_ai/git_client/base.py
@@ -19,7 +19,7 @@ class GitClient(Protocol):
         """Get metadata for the PR given its URL."""
 
     def get_issue_content(self, issues_url: HttpUrl, issue_id: str) -> IssueContent | None:
-        """Fetch the content of an issue from its URL."""
+        """Fetch the content of an issue from the base URL of the issues page."""
 
     def publish_guide(self, pr_url: PRUrl, guide: ReviewGuide) -> None:
         """Publish a review guide to the PR."""


### PR DESCRIPTION
Added support just like for gitlab in #106 

Tested locally:
<img width="844" height="177" alt="image" src="https://github.com/user-attachments/assets/c8a2476b-efce-4dda-82d9-98720432e526" />
