### PR TITLE
refactor(#94): separate issues_client from git_client, add issues-api-key

### DIFF
--- a/src/lgtm_ai/git_client/utils.py
+++ b/src/lgtm_ai/git_client/utils.py
@@ -1,22 +1,21 @@
 import github
 import gitlab
-from lgtm_ai.base.schemas import PRUrl
-from lgtm_ai.config.handler import ResolvedConfig
+from lgtm_ai.base.schemas import IssuesSource, PRSource
 from lgtm_ai.formatters.base import Formatter
 from lgtm_ai.git_client.base import GitClient
 from lgtm_ai.git_client.github import GitHubClient
 from lgtm_ai.git_client.gitlab import GitlabClient
 
 
-def get_git_client(pr_url: PRUrl, config: ResolvedConfig, formatter: Formatter[str]) -> GitClient:
+def get_git_client(source: PRSource | IssuesSource, token: str, formatter: Formatter[str]) -> GitClient:
     """Return a GitClient instance based on the provided PR URL."""
     git_client: GitClient
 
-    if pr_url.source == "gitlab":
-        git_client = GitlabClient(gitlab.Gitlab(private_token=config.git_api_key), formatter=formatter)
-    elif pr_url.source == "github":
-        git_client = GitHubClient(github.Github(login_or_token=config.git_api_key), formatter=formatter)
+    if source == "gitlab":
+        git_client = GitlabClient(gitlab.Gitlab(private_token=token), formatter=formatter)
+    elif source == "github":
+        git_client = GitHubClient(github.Github(login_or_token=token), formatter=formatter)
     else:
-        raise ValueError(f"Unsupported source: {pr_url.source}")
+        raise ValueError(f"Unsupported source: {source}")
 
     return git_client

--- a/src/lgtm_ai/review/guide.py
+++ b/src/lgtm_ai/review/guide.py
@@ -28,7 +28,9 @@ class ReviewGuideGenerator:
         self.model = model
         self.git_client = git_client
         self.config = config
-        self.context_retriever = ContextRetriever(git_client=git_client, httpx_client=httpx.Client(timeout=3))
+        self.context_retriever = ContextRetriever(
+            git_client=git_client, issues_client=git_client, httpx_client=httpx.Client(timeout=3)
+        )
 
     def generate_review_guide(self, pr_url: PRUrl) -> ReviewGuide:
         pr_diff = self.git_client.get_diff_from_url(pr_url)

--- a/src/lgtm_ai/validators.py
+++ b/src/lgtm_ai/validators.py
@@ -89,7 +89,7 @@ class IntOrNoLimitType(click.ParamType):
             self.fail(f"{value!r} is not a valid integer or 'no-limit'", param, ctx)
 
     def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str | None:
-        return "[INTEGER|'no-limit']"
+        return "[INTEGER|no-limit]"
 
 
 def validate_model_url(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:

--- a/tests/config/test_handler.py
+++ b/tests/config/test_handler.py
@@ -261,7 +261,7 @@ def test_issues_configuration_url_not_valid(lgtm_toml_file: str) -> None:
 @pytest.mark.usefixtures("inject_env_secrets")
 def test_issues_configuration_all_present(toml_with_some_issues_configs: str) -> None:
     handler = ConfigHandler(
-        cli_args=PartialConfig(issues_url="https://gitlab.com/user/repo/-/issues"),
+        cli_args=PartialConfig(issues_url="https://gitlab.com/user/repo/-/issues", issues_api_key="key"),
         config_file=toml_with_some_issues_configs,
     )
     config = handler.resolve_config()
@@ -269,6 +269,7 @@ def test_issues_configuration_all_present(toml_with_some_issues_configs: str) ->
     assert config.issues_url == HttpUrl("https://gitlab.com/user/repo/-/issues")
     assert config.issues_source == "gitlab"
     assert config.issues_regex == "some-regex"
+    assert config.issues_api_key == "key"
 
 
 @pytest.mark.usefixtures("inject_env_secrets")


### PR DESCRIPTION
This PR simply refactors how we work with the `ContextRetriever`, to allow future non-git sources for issues.

I created a protocol interface that git clients implement by default (`get_issue_content`), that the future JIRA client may implement.

I added a new `--issues-api-key` that enables different credentials for the git_client (responsible of downloading the code and posting comments) and issues (responsible for reading issues). This works better for future sources that are not git related, but also allows for different issue urls that are not necessarily of the project. A classic example of this would be on GitLab, where issues may be at the group level, and the token used for downloading the code may not have permissions to that group. Now you can optionally pass a `--issues-api-key` with more appropriate permissions for reading issues.

If the user wants to read issues, `--issues-api-key` is not given, and the platform is a git platform, `--git-api-token` will simply be re-used for simplicity: no need to pass the same credentials twice.



Since the `CodeReviewer` class is starting to be THICC, I added more docstrings to it.