### PR TITLE
ci: add coverage comment to gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,12 @@ jobs:
       - name: Test with pytest
         run: |
           just test-all
+
+      - name: Coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-xml-coverage-path: ./coverage.xml
+          junitxml-path: ./pytest.xml
+          unique-id-for-comment: ${{ matrix.python-version }}
+          title: Coverage for Python ${{ matrix.python-version }}
+          report-only-changed-files: true

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ htmlcov/
 .tox/
 .coverage
 coverage.xml
+pytest.xml
 .cache
 .pytest_cache/
 nosetests.xml

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ test *test-args='': venv
 
 # Runs all tests including coverage report.
 test-all: venv
-    {{ run }} pytest
+    {{ run }} pytest --junitxml=pytest.xml --cov-report=xml:coverage.xml
 
 # Format all code in the project.
 format *files=target_dirs: venv


### PR DESCRIPTION
Add GitHub action [pytest-coverage-comment](https://github.com/MishaKav/pytest-coverage-comment) to have visible reports in PRs.

It seems like a well maintained library, and it is easy to use.