### PR TITLE
feat(#97): add code suggestions to GitHub comments

### DIFF
--- a/src/lgtm_ai/__main__.py
+++ b/src/lgtm_ai/__main__.py
@@ -15,7 +15,7 @@ from lgtm_ai.ai.agent import (
 )
 from lgtm_ai.ai.schemas import AgentSettings, CommentCategory, SupportedAIModels, SupportedAIModelsList
 from lgtm_ai.base.schemas import IntOrNoLimit, IssuesSource, OutputFormat, PRUrl
-from lgtm_ai.base.utils import git_source_supports_suggestions
+from lgtm_ai.base.utils import git_source_supports_multiline_suggestions
 from lgtm_ai.config.constants import DEFAULT_INPUT_TOKEN_LIMIT
 from lgtm_ai.config.handler import ConfigHandler, PartialConfig, ResolvedConfig
 from lgtm_ai.formatters.base import Formatter
@@ -178,7 +178,9 @@ def review(
         config_file=config,
     ).resolve_config()
     agent_extra_settings = AgentSettings(retries=resolved_config.ai_retries)
-    formatter: Formatter[Any] = MarkDownFormatter(use_suggestions=git_source_supports_suggestions(pr_url.source))
+    formatter: Formatter[Any] = MarkDownFormatter(
+        add_ranges_to_suggestions=git_source_supports_multiline_suggestions(pr_url.source)
+    )
     git_client = get_git_client(source=pr_url.source, token=resolved_config.git_api_key, formatter=formatter)
     issues_client = _get_issues_client(resolved_config, git_client, formatter)
 

--- a/src/lgtm_ai/base/utils.py
+++ b/src/lgtm_ai/base/utils.py
@@ -14,9 +14,10 @@ def file_matches_any_pattern(file_name: str, patterns: tuple[str, ...]) -> bool:
     return False
 
 
-def git_source_supports_suggestions(source: PRSource) -> bool:
-    """For now, we only support suggestions in GitLab.
+def git_source_supports_multiline_suggestions(source: PRSource) -> bool:
+    """Check if the given git source supports multiline suggestions.
 
-    TODO: https://github.com/elementsinteractive/lgtm-ai/issues/96
+    GitLab does support specifying suggestions that span multiple lines in single-line comments.
+    GitHub requires the comment to be multi-line, and the suggestion does not need special markup with ranges.
     """
     return source == PRSource.gitlab

--- a/src/lgtm_ai/formatters/markdown.py
+++ b/src/lgtm_ai/formatters/markdown.py
@@ -15,8 +15,8 @@ class MarkDownFormatter(Formatter[str]):
     SNIPPET_TEMPLATE: ClassVar[str] = "snippet.md.j2"
     METADATA_TEMPLATE: ClassVar[str] = "metadata.md.j2"
 
-    def __init__(self, use_suggestions: bool = False) -> None:
-        self.use_suggestions = use_suggestions
+    def __init__(self, add_ranges_to_suggestions: bool = False) -> None:
+        self.add_ranges_to_suggestions = add_ranges_to_suggestions
         template_dir = pathlib.Path(__file__).parent / "templates"
         self._template_env = Environment(loader=FileSystemLoader(template_dir), autoescape=True)
 
@@ -52,7 +52,7 @@ class MarkDownFormatter(Formatter[str]):
             snippet=snippet,
             comment=comment.comment,
             suggestion=comment.suggestion,
-            use_suggestions=self.use_suggestions,
+            add_ranges_to_suggestions=self.add_ranges_to_suggestions,
             with_footer=with_footer,
             new_path=comment.new_path,
             line_number=comment.line_number,

--- a/src/lgtm_ai/formatters/templates/review_comment.md.j2
+++ b/src/lgtm_ai/formatters/templates/review_comment.md.j2
@@ -9,8 +9,8 @@
 {{ comment | safe }}
 
 {% if suggestion %}
-{% if use_suggestions and suggestion.ready_for_replacement %}
-`````suggestion:{{ suggestion.start_offset.direction}}{{ suggestion.start_offset.offset }}{{ suggestion.end_offset.direction }}{{ suggestion.end_offset.offset }}
+{% if suggestion.ready_for_replacement %}
+`````suggestion{% if add_ranges_to_suggestions %}:{{ suggestion.start_offset.direction}}{{ suggestion.start_offset.offset }}{{ suggestion.end_offset.direction }}{{ suggestion.end_offset.offset }}{% endif %}
 {{ suggestion.snippet | safe }}
 `````
 {% else %}

--- a/tests/formatters/test_markdown.py
+++ b/tests/formatters/test_markdown.py
@@ -168,7 +168,7 @@ class TestMarkdownFormatter:
         assert self.formatter.format_review_comments_section(review.review_response.comments).split("\n") == expected
 
     def test_format_comments_with_suggestions(self) -> None:
-        formatter = MarkDownFormatter(use_suggestions=True)
+        formatter = MarkDownFormatter(add_ranges_to_suggestions=True)
         review = Review(
             metadata=PublishMetadata(model_name="whatever", usage=MOCK_USAGE),
             review_response=ReviewResponse(
@@ -223,16 +223,20 @@ class TestMarkdownFormatter:
         assert formatter.format_review_comments_section(review.review_response.comments).split("\n") == expected
 
     @pytest.mark.parametrize(
-        ("use_suggestions", "ready_for_replacement"),
+        ("add_ranges_to_suggestions", "ready_for_replacement", "header"),
         [
-            (True, False),  # should not format as suggestion block if not ready
-            (False, True),  # even if ready, should not format as suggestion block if use_suggestions is False
+            (True, False, "python"),  # should not format as suggestion block if not ready
+            (
+                False,
+                True,
+                "suggestion",
+            ),  # even if ready, should not add ranges if the flag is off
         ],
     )
     def test_format_comments_with_suggestions_but_formatted_normally(
-        self, use_suggestions: bool, ready_for_replacement: bool
+        self, add_ranges_to_suggestions: bool, ready_for_replacement: bool, header: str
     ) -> None:
-        formatter = MarkDownFormatter(use_suggestions=use_suggestions)
+        formatter = MarkDownFormatter(add_ranges_to_suggestions=add_ranges_to_suggestions)
         review = Review(
             metadata=PublishMetadata(model_name="whatever", usage=MOCK_USAGE),
             review_response=ReviewResponse(
@@ -274,7 +278,7 @@ class TestMarkdownFormatter:
             "",
             "",
             "",
-            "`````python",  # not a suggestion block
+            f"`````{header}",
             "print('Hello World')",
             "`````",
             "",


### PR DESCRIPTION
A bunch of examples in:
- https://github.com/scastlara/lgtm-ai/pull/2
- https://github.com/scastlara/lgtm-ai/pull/1

It is not clear to me why, but sometimes we fail to post comments successfully. It seems to me like the AI is mixing up line numbers, or we are not giving it enough info to add the correct metadata to the comments. For now, I've implemented a fallback that simply uses the good ol' single line comments.


I will collect data of examples of failing comments and create an issue out of them to fix later 👍 

<details>

<summary>Examples:</summary>

```python
comment1 = ReviewComment(
    old_path="src/lgtm_ai/__main__.py",
    new_path="src/lgtm_ai/__main__.py",
    comment="The `JsonFormatter` import was removed on line 21 (relative line 15), but it is still used in the `_get_formatter_and_printer` function. This will result in a `NameError` if `output_format` is `OutputFormat.json`. Please re-add the import.",
    category="Correctness",
    severity="HIGH",
    line_number=21,
    relative_line_number=15,
    is_comment_on_new_path=True,
    programming_language="python",
    quote_snippet="from lgtm_ai.formatters.json import JsonFormatter",
    suggestion=CodeSuggestion(
        start_offset=CodeSuggestionOffset(offset=0, direction="-"),
        end_offset=CodeSuggestionOffset(offset=0, direction="-"),
        snippet="from lgtm_ai.formatters.json import JsonFormatter",
        programming_language="python",
        ready_for_replacement=True
    )
)

# Comment 2: ReviewGuideGenerator needs ContextRetriever parameter
comment2 = ReviewComment(
    old_path="src/lgtm_ai/review/guide.py",
    new_path="src/lgtm_ai/review/guide.py",
    comment="The `ReviewGuideGenerator` currently hardcodes the `issues_client` to `git_client` when initializing its `ContextRetriever`. To correctly utilize the new issues client separation logic, the `ReviewGuideGenerator`'s `__init__` method should be updated to accept a `ContextRetriever` instance directly. This allows `__main__.py` to provide a pre-configured `ContextRetriever` that already incorporates the correct `issues_client` based on the resolved configuration.",
    category="Correctness",
    severity="HIGH",
    line_number=31,
    relative_line_number=5,
    is_comment_on_new_path=True,
    programming_language="python",
    quote_snippet="self.context_retriever = ContextRetriever(\n            git_client=git_client, issues_client=git_client,\n            httpx_client=httpx.Client(timeout=3)\n        )",
    suggestion=CodeSuggestion(
        start_offset=CodeSuggestionOffset(offset=4, direction="-"),
        end_offset=CodeSuggestionOffset(offset=2, direction="+"),
        snippet="        def __init__(\n            self,\n            guide_agent: Agent[GuideDeps, GuideResponse],\n            model: Model,\n            git_client: GitClient,\n            config: ResolvedConfig,\n            context_retriever: ContextRetriever,\n        ) -> None:\n            self.guide_agent = guide_agent\n            self.model = model\n            self.git_client = git_client\n            self.config = config\n            self.context_retriever = context_retriever",
        programming_language="python",
        ready_for_replacement=True
    )
)

# Comment 3: Guide command needs proper issues client setup
comment3 = ReviewComment(
    old_path="src/lgtm_ai/__main__.py",
    new_path="src/lgtm_ai/__main__.py",
    comment="In the `guide` command, the `ReviewGuideGenerator` is currently instantiated without a `ContextRetriever` that utilizes the dedicated issues client logic. This means the `guide` command will not correctly use a separate issues client (with its own API key or non-Git source) even if configured. To resolve this, `_get_issues_client` should be called to determine the appropriate `issues_client`, then a `ContextRetriever` should be constructed with both `git_client` and this `issues_client`, and finally, this `context_retriever` should be passed to the `ReviewGuideGenerator`.",
    category="Correctness",
    severity="HIGH",
    line_number=250,
    relative_line_number=122,
    is_comment_on_new_path=True,
    programming_language="python",
    quote_snippet="    git_client = get_git_client(source=pr_url.source, token=resolved_config.git_api_key, formatter=MarkDownFormatter())\n    review_guide = ReviewGuideGenerator(\n        guide_agent=get_guide_agent_with_settings(agent_extra_settings),\n        model=get_ai_model(\n            model_name=resolved_config.model,\n            api_key=resolved_config.ai_api_key,\n            model_url=resolved_config.model_url\n        ),\n        git_client=git_client,\n        config=resolved_config,\n    )",
    suggestion=CodeSuggestion(
        start_offset=CodeSuggestionOffset(offset=0, direction="-"),
        end_offset=CodeSuggestionOffset(offset=8, direction="+"),
        snippet="    formatter: Formatter[Any] = MarkDownFormatter()\n    git_client = get_git_client(source=pr_url.source, token=resolved_config.git_api_key, formatter=formatter)\n    issues_client = _get_issues_client(resolved_config, git_client, formatter)\n\n    context_retriever = ContextRetriever(git_client=git_client, issues_client=issues_client, httpx_client=httpx.Client(timeout=3))\n\n    review_guide = ReviewGuideGenerator(\n        guide_agent=get_guide_agent_with_settings(agent_extra_settings),\n        model=get_ai_model(\n            model_name=resolved_config.model,\n            api_key=resolved_config.ai_api_key,\n            model_url=resolved_config.model_url\n        ),\n        git_client=git_client,\n        config=resolved_config,\n        context_retriever=context_retriever,\n    )",
        programming_language="python",
        ready_for_replacement=True
    )
)
```

</details>