### PR TITLE
fix(#86): make terminal formatter comments not truncated, and add suggestions

### DIFF
--- a/scripts/evaluate_review_quality.py
+++ b/scripts/evaluate_review_quality.py
@@ -7,12 +7,14 @@ from unittest import mock
 
 import click
 import gitlab
+import httpx
 from lgtm_ai.ai.agent import get_ai_model, get_reviewer_agent_with_settings, get_summarizing_agent_with_settings
 from lgtm_ai.ai.schemas import Review, SupportedAIModels, SupportedAIModelsList
 from lgtm_ai.config.handler import ResolvedConfig
 from lgtm_ai.formatters.markdown import MarkDownFormatter
 from lgtm_ai.git_client.gitlab import GitlabClient
 from lgtm_ai.review import CodeReviewer
+from lgtm_ai.review.context import ContextRetriever
 from lgtm_ai.validators import parse_pr_url
 from rich.logging import RichHandler
 
@@ -93,11 +95,15 @@ def perform_review(
     output_dir: str, pr_url: str, pr_name: str, sample: int, model: SupportedAIModels, git_api_key: str, ai_api_key: str
 ) -> None:
     url = parse_pr_url(mock.Mock(), "pr_url", pr_url)
+    git_client = GitlabClient(client=gitlab.Gitlab(private_token=git_api_key), formatter=MarkDownFormatter())
     code_reviewer = CodeReviewer(
         reviewer_agent=get_reviewer_agent_with_settings(),
         summarizing_agent=get_summarizing_agent_with_settings(),
         model=get_ai_model(model_name=model, api_key=ai_api_key),
-        git_client=GitlabClient(gitlab.Gitlab(private_token=git_api_key), formatter=MarkDownFormatter()),
+        git_client=git_client,
+        context_retriever=ContextRetriever(
+            git_client=git_client, issues_client=git_client, httpx_client=httpx.Client(timeout=3)
+        ),
         config=ResolvedConfig(model=model, technologies=("Python", "Django", "FastAPI")),
     )
     review = code_reviewer.review_pull_request(pr_url=url)

--- a/src/lgtm_ai/__main__.py
+++ b/src/lgtm_ai/__main__.py
@@ -6,7 +6,6 @@ from typing import Any, assert_never, get_args
 
 import click
 import httpx
-import rich
 from lgtm_ai.ai.agent import (
     get_ai_model,
     get_guide_agent_with_settings,
@@ -284,7 +283,8 @@ def _set_logging_level(logger: logging.Logger, verbose: int) -> None:
 def _get_formatter_and_printer(output_format: OutputFormat) -> tuple[Formatter[Any], Callable[[Any], None]]:
     """Get the formatter and the print method based on the output format."""
     if output_format == OutputFormat.pretty:
-        return PrettyFormatter(), rich.print
+        console = Console()
+        return PrettyFormatter(), console.print
     elif output_format == OutputFormat.markdown:
         return MarkDownFormatter(), print
     elif output_format == OutputFormat.json:

--- a/tests/formatters/test_terminal.py
+++ b/tests/formatters/test_terminal.py
@@ -42,14 +42,13 @@ def test_format_comments_section() -> None:
     ]
 
     formatter = PrettyFormatter()
-    layout = formatter.format_review_comments_section(comments)
-    assert len(layout.children) == 3
-    child_panels = [child._renderable for child in layout.children]
-    assert all(isinstance(child, rich.panel.Panel) for child in child_panels)
-    assert all(cast(rich.panel.Panel, child).title == "test.py:1" for child in child_panels)
+    group = formatter.format_review_comments_section(comments)
+    assert len(group.renderables) == 3
+    assert all(isinstance(child, rich.panel.Panel) for child in group.renderables)
+    assert all(cast(rich.panel.Panel, child).title == "test.py:1" for child in group.renderables)
 
 
 def test_format_comments_section_no_comments() -> None:
     formatter = PrettyFormatter()
-    layout = formatter.format_review_comments_section([])
-    assert len(layout.children) == 0
+    group = formatter.format_review_comments_section([])
+    assert len(group.renderables) == 0


### PR DESCRIPTION

This is how it looks:

<img width="728" height="1128" alt="image" src="https://github.com/user-attachments/assets/7ea2f883-c16f-4abf-8c0b-95e26f5b9375" />

No matter how many comments we get, we don't truncate them. The problem was using `rich.Layout` instead of `rich.Group`.
