### PR TITLE
chore: change `--issues-source` to `--issues-platform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,17 @@ lgtm-ai can enhance code reviews by including context from linked issues or user
 
 - Provide the following options to the `lgtm review` command:
   - `--issues-url`: The base URL of the issues or user story page.
-  - `--issues-source`: The platform for the issues (e.g., `github`, `gitlab`, `jira`).
+  - `--issues-platform`: The platform for the issues (e.g., `github`, `gitlab`, `jira`).
   - `--issues-regex`: (Optional) A regex pattern to extract the issue ID from the PR title or description.
-  - `--issues-api-key`: (Optional) API key for the issues service (if different from `--git-api-key`).
-  - `--issues-user`: (Optional) Username for the issues service (required if source is `jira`).
+  - `--issues-api-key`: (Optional) API key for the issues platform (if different from `--git-api-key`).
+  - `--issues-user`: (Optional) Username for the issues platform (required if source is `jira`).
 
 **Example:**
 ```sh
 lgtm review \
   --pr-url "https://github.com/your-org/your-repo/pull/42" \
   --issues-url "https://github.com/your-org/your-repo/issues" \
-  --issues-source github \
+  --issues-platform github \
   --issues-regex "(?:Fixes|Resolves) #(\d+)" \
   --issues-api-key $GITHUB_TOKEN \
   ...
@@ -389,11 +389,11 @@ When it comes to preference for selecting options, lgtm follows this preference 
 | technologies         | Review Only          | 🟢 Optional                   | List of technologies for reviewer expertise.                                     |
 | categories           | Review Only          | 🟢 Optional                   | Review categories. Defaults to all (`Quality`, `Correctness`, `Testing`, `Security`). |
 | additional_context   | Review Only          | 🟢 Optional                   | Extra context for the LLM (array of prompts/paths/URLs). Can't be given through the CLI |
-| issues_url           | Issues Integration   | 🟢 Optional                   | Enables issue context. If set, `issues_source` becomes required.                 |
-| issues_source        | Issues Integration   | 🟡 Conditionally required     | Required if `issues_url` is set.                                                 |
+| issues_url           | Issues Integration   | 🟢 Optional                   | Enables issue context. If set, `issues_platform` becomes required.                 |
+| issues_platform        | Issues Integration   | 🟡 Conditionally required     | Required if `issues_url` is set.                                                 |
 | issues_regex         | Issues Integration   | 🟢 Optional                   | Regex for issue ID extraction. Defaults to conventional commit compatible regex. |
-| issues_api_key       | Issues Integration   | 🟢 Optional                   | API key for issues service (if different from `git_api_key`). Can't be given through config file. Also available through env variable `LGTM_ISSUES_API_KEY`.                         |
-| issues_user       | Issues Integration   | 🟡 Conditionally required    | Username for accessing issues information. Only required for `issues_source=jira` |
+| issues_api_key       | Issues Integration   | 🟢 Optional                   | API key for issues platform (if different from `git_api_key`). Can't be given through config file. Also available through env variable `LGTM_ISSUES_API_KEY`.                         |
+| issues_user       | Issues Integration   | 🟡 Conditionally required    | Username for accessing issues information. Only required for `issues_platform=jira` |
 
 </details>
 
@@ -424,11 +424,11 @@ These options are only used when performing reviews through the command `lgtm re
 
 See [Using Issue/User Story Information section](#using-issueuser-story-information).
 
-- **issues_url**: The base URL of the issues or user story page to fetch additional context for the PR. If set, `issues_source` becomes required.
-- **issues_source**: The platform for the issues (e.g., `github`, `gitlab`, `jira`). Required if `issues_url` is set.
+- **issues_url**: The base URL of the issues or user story page to fetch additional context for the PR. If set, `issues_platform` becomes required.
+- **issues_platform**: The platform for the issues (e.g., `github`, `gitlab`, `jira`). Required if `issues_url` is set.
 - **issues_regex**: A regex pattern to extract the issue ID from the PR title or description. If omitted, lgtm uses a default regex compatible with conventional commits and common PR formats.
-- **issues_api_key**: API key for the issues service (if different from `git_api_key`). Can be given as a CLI argument, or as an environment variable (`LGTM_ISSUES_API_KEY`).
-- **issues_user**: Username for accessing the issues service (only necessary for `jira`). Can be given as a CLI argument, or as an environment variable (`LGTM_ISSUES_USER`).
+- **issues_api_key**: API key for the issues platform (if different from `git_api_key`). Can be given as a CLI argument, or as an environment variable (`LGTM_ISSUES_API_KEY`).
+- **issues_user**: Username for accessing the issues platform (only necessary for `jira`). Can be given as a CLI argument, or as an environment variable (`LGTM_ISSUES_USER`).
 
 #### Example `lgtm.toml`
 
@@ -459,7 +459,7 @@ context = '''
 
 # Optional Issue/user story integration
 issues_url = "https://github.com/your-org/your-repo/issues"
-issues_source = "github"
+issues_platform = "github"
 # The options below are optional even if the two above are provided
 issues_regex = "(?:Fixes|Resolves) #(\d+)"
 issues_api_key = "${GITHUB_TOKEN}"

--- a/src/lgtm_ai/base/schemas.py
+++ b/src/lgtm_ai/base/schemas.py
@@ -11,14 +11,14 @@ class PRSource(StrEnum):
     gitlab = "gitlab"
 
 
-class IssuesSource(StrEnum):
+class IssuesPlatform(StrEnum):
     github = "github"
     gitlab = "gitlab"
     jira = "jira"
 
     @property
     def is_git_platform(self) -> bool:
-        return self in {IssuesSource.gitlab, IssuesSource.github}
+        return self in {IssuesPlatform.gitlab, IssuesPlatform.github}
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/lgtm_ai/config/handler.py
+++ b/src/lgtm_ai/config/handler.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal, Self, cast, get_args, overload
 
 from lgtm_ai.ai.schemas import AdditionalContext, CommentCategory, SupportedAIModels
-from lgtm_ai.base.schemas import IntOrNoLimit, IssuesSource, OutputFormat
+from lgtm_ai.base.schemas import IntOrNoLimit, IssuesPlatform, OutputFormat
 from lgtm_ai.config.constants import DEFAULT_AI_MODEL, DEFAULT_INPUT_TOKEN_LIMIT, DEFAULT_ISSUE_REGEX
 from lgtm_ai.config.exceptions import (
     ConfigFileNotFoundError,
@@ -41,7 +41,7 @@ class PartialConfig(BaseModel):
     ai_input_tokens_limit: IntOrNoLimit | None = None
     issues_url: str | None = None
     issues_regex: str | None = None
-    issues_source: IssuesSource | None = None
+    issues_platform: IssuesPlatform | None = None
 
     # Secrets
     git_api_key: str | None = None
@@ -95,7 +95,7 @@ class ResolvedConfig(BaseModel):
     issues_regex: Annotated[str, AfterValidator(validate_regex)] = DEFAULT_ISSUE_REGEX
     """Regex to extract issue ID from the PR title and description."""
 
-    issues_source: IssuesSource | None = None
+    issues_platform: IssuesPlatform | None = None
     """The platform of the issues page."""
 
     # Secrets
@@ -106,23 +106,23 @@ class ResolvedConfig(BaseModel):
     """API key to interact with the AI model service (OpenAI, etc.)."""
 
     issues_api_key: str | None = Field(default=None, repr=False)
-    """API key to interact with the issues service (GitHub, GitLab, Jira, etc.)."""
+    """API key to interact with the issues platform (GitHub, GitLab, Jira, etc.)."""
 
     issues_user: str | None = Field(default=None, repr=False)
-    """Username to interact with the issues service (only needed for Jira)."""
+    """Username to interact with the issues platform (only needed for Jira)."""
 
     @model_validator(mode="after")
     def validate_issues_options(self) -> Self:
-        all_fields = (self.issues_url, self.issues_source)
+        all_fields = (self.issues_url, self.issues_platform)
         if any(field is not None for field in all_fields) and not all(field is not None for field in all_fields):
             raise MissingRequiredConfigError(
                 "If any `--issues-*` configuration is provided, all issues fields must be provided. Check --help."
             )
-        if self.issues_source is not None and not self.issues_source.is_git_platform and not self.issues_api_key:
+        if self.issues_platform is not None and not self.issues_platform.is_git_platform and not self.issues_api_key:
             raise MissingRequiredConfigError(
-                f"An API key is required to access issues from {self.issues_source.value}. Please provide it via the --issues-api-key option or the LGTM_ISSUES_API_KEY environment variable."
+                f"An API key is required to access issues from {self.issues_platform.value}. Please provide it via the --issues-api-key option or the LGTM_ISSUES_API_KEY environment variable."
             )
-        if self.issues_source == IssuesSource.jira and (not self.issues_user or not self.issues_api_key):
+        if self.issues_platform == IssuesPlatform.jira and (not self.issues_user or not self.issues_api_key):
             raise MissingRequiredConfigError(
                 "A username and an api key are required to access issues from Jira. Please provide them via the --issues-user and --issues-api-key options."
             )
@@ -184,7 +184,7 @@ class ConfigHandler:
                 ai_retries=config_data.get("ai_retries", None),
                 ai_input_tokens_limit=config_data.get("ai_input_tokens_limit", None),
                 issues_url=config_data.get("issues_url", None),
-                issues_source=config_data.get("issues_source", None),
+                issues_platform=config_data.get("issues_platform", None),
                 issues_regex=config_data.get("issues_regex", None),
             )
         except ValidationError as err:
@@ -247,7 +247,7 @@ class ConfigHandler:
             ai_retries=self.cli_args.ai_retries or None,
             ai_input_tokens_limit=self.cli_args.ai_input_tokens_limit or None,
             issues_url=self.cli_args.issues_url or None,
-            issues_source=self.cli_args.issues_source or None,
+            issues_platform=self.cli_args.issues_platform or None,
             issues_regex=self.cli_args.issues_regex or None,
             issues_api_key=self.cli_args.issues_api_key or None,
             issues_user=self.cli_args.issues_user or None,
@@ -301,7 +301,7 @@ class ConfigHandler:
                 ),
                 issues_regex=from_cli.issues_regex or from_file.issues_regex or DEFAULT_ISSUE_REGEX,
                 issues_url=from_cli.issues_url or from_file.issues_url,
-                issues_source=from_cli.issues_source or from_file.issues_source,
+                issues_platform=from_cli.issues_platform or from_file.issues_platform,
                 issues_api_key=self.resolver.resolve_string_field(
                     "issues_api_key", from_cli=from_cli, from_env=from_env, required=False, default=None
                 ),

--- a/src/lgtm_ai/git_client/utils.py
+++ b/src/lgtm_ai/git_client/utils.py
@@ -1,13 +1,13 @@
 import github
 import gitlab
-from lgtm_ai.base.schemas import IssuesSource, PRSource
+from lgtm_ai.base.schemas import IssuesPlatform, PRSource
 from lgtm_ai.formatters.base import Formatter
 from lgtm_ai.git_client.base import GitClient
 from lgtm_ai.git_client.github import GitHubClient
 from lgtm_ai.git_client.gitlab import GitlabClient
 
 
-def get_git_client(source: PRSource | IssuesSource, token: str, formatter: Formatter[str]) -> GitClient:
+def get_git_client(source: PRSource | IssuesPlatform, token: str, formatter: Formatter[str]) -> GitClient:
     """Return a GitClient instance based on the provided PR URL."""
     git_client: GitClient
 

--- a/src/lgtm_ai/review/reviewer.py
+++ b/src/lgtm_ai/review/reviewer.py
@@ -132,7 +132,7 @@ class CodeReviewer:
             pr_url=pr_url,
             additional_context=self.config.additional_context,
         )
-        if self.config.issues_source and self.config.issues_url and self.config.issues_regex:
+        if self.config.issues_platform and self.config.issues_url and self.config.issues_regex:
             logger.info("Fetching issue context related to the PR")
             issue_context = self.context_retriever.get_issues_context(
                 issues_url=self.config.issues_url,

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -101,7 +101,7 @@ def toml_with_invalid_config_field(tmp_path: Path) -> Iterator[str]:
 def toml_with_some_issues_configs(tmp_path: Path) -> Iterator[str]:
     pyproject_toml = tmp_path / "lgtm.toml"
     data = """
-    issues_source = "gitlab"
+    issues_platform = "gitlab"
     issues_regex = "some-regex"
     """
     with create_tmp_file(pyproject_toml, data) as tmp_file:

--- a/tests/config/test_handler.py
+++ b/tests/config/test_handler.py
@@ -267,7 +267,7 @@ def test_issues_configuration_all_present(toml_with_some_issues_configs: str) ->
     config = handler.resolve_config()
 
     assert config.issues_url == HttpUrl("https://gitlab.com/user/repo/-/issues")
-    assert config.issues_source == "gitlab"
+    assert config.issues_platform == "gitlab"
     assert config.issues_regex == "some-regex"
     assert config.issues_api_key == "key"
 
@@ -275,7 +275,7 @@ def test_issues_configuration_all_present(toml_with_some_issues_configs: str) ->
 @pytest.mark.usefixtures("inject_env_secrets")
 def test_issues_regex_uses_default(lgtm_toml_file: str) -> None:
     handler = ConfigHandler(
-        cli_args=PartialConfig(issues_url="https://gitlab.com/user/repo/-/issues", issues_source="gitlab"),
+        cli_args=PartialConfig(issues_url="https://gitlab.com/user/repo/-/issues", issues_platform="gitlab"),
         config_file=lgtm_toml_file,
     )
     config = handler.resolve_config()
@@ -287,7 +287,7 @@ def test_issues_regex_uses_default(lgtm_toml_file: str) -> None:
 def test_issues_regex_invalid() -> None:
     handler = ConfigHandler(
         cli_args=PartialConfig(
-            issues_url="https://gitlab.com/user/repo/-/issues", issues_source="gitlab", issues_regex="*bad-regex"
+            issues_url="https://gitlab.com/user/repo/-/issues", issues_platform="gitlab", issues_regex="*bad-regex"
         ),
         config_file=None,
     )
@@ -300,7 +300,7 @@ def test_issues_jira_missing_user() -> None:
     handler = ConfigHandler(
         cli_args=PartialConfig(
             issues_url="https://test.atlassian.net/browse/",
-            issues_source="jira",
+            issues_platform="jira",
             issues_api_key="api-key",
         ),
         config_file=None,

--- a/tests/review/test_reviewer.py
+++ b/tests/review/test_reviewer.py
@@ -187,7 +187,7 @@ def test_get_review_with_issue(context_retriever: ContextRetriever) -> None:
                         context="yet-another-context",
                     ),
                 ),
-                issues_source="gitlab",
+                issues_platform="gitlab",
                 issues_url="https://gitlab.com/example/repo/-/issues/",
             ),
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ import click
 import pytest
 from click.testing import CliRunner
 from lgtm_ai.__main__ import _set_logging_level, guide, review
-from lgtm_ai.base.schemas import IssuesSource
+from lgtm_ai.base.schemas import IssuesPlatform
 
 
 @pytest.mark.parametrize(
@@ -189,16 +189,16 @@ def test_get_formatter_and_printer(output_format: str, expected_formatter: str, 
 
 
 @pytest.mark.parametrize(
-    ("issues_source", "given_issues_token", "expect_reuse_git_client", "expected_token"),
+    ("issues_platform", "given_issues_token", "expect_reuse_git_client", "expected_token"),
     [
-        (IssuesSource.gitlab, None, True, "git-token"),
-        (IssuesSource.gitlab, "issues-token", False, "issues-token"),
-        (IssuesSource.github, None, True, "git-token"),
-        (IssuesSource.github, "issues-token", False, "issues-token"),
+        (IssuesPlatform.gitlab, None, True, "git-token"),
+        (IssuesPlatform.gitlab, "issues-token", False, "issues-token"),
+        (IssuesPlatform.github, None, True, "git-token"),
+        (IssuesPlatform.github, "issues-token", False, "issues-token"),
     ],
 )
 def test_review_issues_correct_issues_client_according_to_cli(
-    issues_source: IssuesSource, given_issues_token: str | None, expect_reuse_git_client: bool, expected_token: str
+    issues_platform: IssuesPlatform, given_issues_token: str | None, expect_reuse_git_client: bool, expected_token: str
 ) -> None:
     runner = CliRunner()
     extra_cli_args = ["--issues-api-key", given_issues_token] if given_issues_token else []
@@ -219,8 +219,8 @@ def test_review_issues_correct_issues_client_according_to_cli(
                 "git-token",
                 "--issues-url",
                 "https://gitlab.com/user/repo/-/issues",
-                "--issues-source",
-                issues_source.value,
+                "--issues-platform",
+                issues_platform.value,
                 *extra_cli_args,
             ],
             catch_exceptions=False,


### PR DESCRIPTION
Not a fan of the name. I also want parity for the future `--git-platform`. 
So now's the moment since we are below v1.