### PR TITLE
refactor: pr_url is no longer an option, but an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ lgtm-ai is your AI-powered code review companion. It generates code reviews usin
 ### Review
 
 ```sh
- lgtm review --pr-url "https://gitlab.com/your-repo/-/merge-requests/42" \
-             --ai-api-key $OPENAI_API_KEY \
+ lgtm review --ai-api-key $OPENAI_API_KEY \
              --git-api-key $GITLAB_TOKEN \
              --model gpt-4.1 \
-             --publish
+             --publish \
+             "https://gitlab.com/your-repo/-/merge-requests/42"
 ```
 
 This will generate a **review** like this one:
@@ -67,11 +67,11 @@ This will generate a **review** like this one:
 ### Reviewer Guide
 
 ```sh
- lgtm guide --pr-url "https://gitlab.com/your-repo/-/merge-requests/42" \
-             --ai-api-key $OPENAI_API_KEY \
+ lgtm guide  --ai-api-key $OPENAI_API_KEY \
              --git-api-key $GITLAB_TOKEN \
              --model gpt-4.1 \
-             --publish
+             --publish \
+             "https://gitlab.com/your-repo/-/merge-requests/42"
 ```
 
 This will generate a **reviewer guide** like this one:
@@ -130,7 +130,7 @@ lgtm aims to work with as many services as possible, and that includes remote re
 - [GitLab](https://gitlab.com) (only gitlab.com, not self-hosted)
 - [GitHub](https://github.com)
 
-lgtm will autodetect the url of the pull request passed to `--pr-url`.
+lgtm will autodetect the url of the pull request passed as an argument.
 
 
 ### Using Issue/User Story Information
@@ -149,12 +149,12 @@ lgtm-ai can enhance code reviews by including context from linked issues or user
 **Example:**
 ```sh
 lgtm review \
-  --pr-url "https://github.com/your-org/your-repo/pull/42" \
   --issues-url "https://github.com/your-org/your-repo/issues" \
   --issues-platform github \
   --issues-regex "(?:Fixes|Resolves) #(\d+)" \
   --issues-api-key $GITHUB_TOKEN \
   ...
+  "https://github.com/your-org/your-repo/pull/42"
 ```
 
 - These options can also be set in the `lgtm.toml` configuration file, see more in the [configuration section](#configuration).
@@ -315,10 +315,10 @@ You can run lgtm against a model available at a custom url (say, models running 
 
 ```sh
 lgtm review \
-  --pr-url https://github.com/group/repo/pull/1 \
   --model llama3.2 \
   --model-url http://localhost:11434/v1 \
   ...
+  https://github.com/group/repo/pull/1
 ```
 
 ### CI/CD Integration
@@ -338,7 +338,7 @@ lgtm-review:
    - if: $CI_MERGE_REQUEST_ID
   when: manual
   script:
-    - lgtm review --pr-url ${MR_URL} --git-api-key ${LGTM_GIT_API_KEY} --ai-api-key ${LGTM_AI_API_KEY} -v
+    - lgtm review --git-api-key ${LGTM_GIT_API_KEY} --ai-api-key ${LGTM_AI_API_KEY} -v ${MR_URL}
   variables:
     MR_URL: "${CI_PROJECT_URL}/-/merge_requests/${CI_MERGE_REQUEST_IID}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,6 @@ runs:
         # Build arguments as an array for safety (avoids word-splitting issues)
         ARGS=(
           review
-          --pr-url "https://github.com/${{ github.repository }}/pull/${{ inputs.pr-number }}"
           --git-api-key "${{ inputs.git-api-key }}"
           --ai-api-key "${{ inputs.ai-api-key }}"
         )
@@ -90,4 +89,5 @@ runs:
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           elementsinteractive/lgtm-ai:${{ inputs.version }} \
-          "${ARGS[@]}"
+          "${ARGS[@]}" \
+          "https://github.com/${{ github.repository }}/pull/${{ inputs.pr-number }}"

--- a/src/lgtm_ai/__main__.py
+++ b/src/lgtm_ai/__main__.py
@@ -56,7 +56,7 @@ def entry_point() -> None:
 def _common_options[**P, T](func: Callable[P, T]) -> Callable[P, T]:
     """Wrap a click command and adds common options for lgtm commands."""
 
-    @click.option("--pr-url", required=True, help="The URL of the pull request to work on.", callback=parse_pr_url)
+    @click.argument("pr-url", required=True, callback=parse_pr_url)
     @click.option(
         "--model",
         type=ModelChoice(SupportedAIModelsList),
@@ -156,7 +156,10 @@ def review(
     issues_api_key: str | None,
     issues_user: str | None,
 ) -> None:
-    """Review a Pull Request using AI."""
+    """Review a Pull Request using AI.
+
+    PR_URL is the URL of the pull request to review.
+    """
     _set_logging_level(logger, verbose)
 
     logger.info("lgtm-ai version: %s", __version__)
@@ -236,7 +239,10 @@ def guide(
     ai_input_tokens_limit: IntOrNoLimit | None,
     verbose: int,
 ) -> None:
-    """Generate a review guide for a Pull Request using AI."""
+    """Generate a review guide for a Pull Request using AI.
+
+    PR_URL is the URL of the pull request to generate a guide for.
+    """
     _set_logging_level(logger, verbose)
 
     logger.info("lgtm-ai version: %s", __version__)

--- a/tests/git_parser/fixtures.py
+++ b/tests/git_parser/fixtures.py
@@ -212,3 +212,125 @@ COMPLEX_DIFF_TEXT = '''
 +    else:
 +        assert_never(output_format)
 '''
+
+
+GIT_SHOW = r"""
+diff --git src/lgtm_ai/config/constants.py src/lgtm_ai/config/constants.py
+index 229c1ed..51688bc 100644
+--- src/lgtm_ai/config/constants.py
++++ src/lgtm_ai/config/constants.py
+@@ -2,4 +2,4 @@ from lgtm_ai.ai.schemas import SupportedAIModels
+
+ DEFAULT_AI_MODEL: SupportedAIModels = "gemini-2.0-flash"
+ DEFAULT_INPUT_TOKEN_LIMIT = 500000
+-DEFAULT_ISSUE_REGEX = r"(?:refs?|closes?)[:\s]*((?:#\d+)|(?:#?[A-Z]+-\d+))|(?:fix|feat|docs|style|refactor|perf|test|build|ci)\((?:#(\d+)|#?([A-Z]+-\d+))\)!?:"
++DEFAULT_ISSUE_REGEX = r"(?:refs?|closes?|resolves?)[:\s]*((?:#\d+)|(?:#?[A-Z]+-\d+))|(?:fix|feat|docs|style|refactor|perf|test|build|ci)\((?:#(\d+)|#?([A-Z]+-\d+))\)!?:"
+diff --git tests/review/test_context.py tests/review/test_context.py
+index 69f3efc..b47cb94 100644
+--- tests/review/test_context.py
++++ tests/review/test_context.py
+@@ -203,6 +203,14 @@ class TestIssueContext:
+                 "456",
+                 id="number-with-hash-in-title-and-description",
+             ),
++            pytest.param(
++                PRMetadata(
++                    title="fix: Bug fix for issue #456",
++                    description="Resolves #456 and relates to PROJ-789.",
++                ),
++                "456",
++                id="number-with-resolves-in-description",
++            ),
+             pytest.param(
+                 PRMetadata(
+                     title="fix: Bug fix for issue 456",
+
+"""
+
+PARSED_GIT_SHOW = DiffResult(
+    metadata=DiffFileMetadata(
+        new_file=True, deleted_file=False, renamed_file=False, new_path="example.txt", old_path="example.txt"
+    ),
+    modified_lines=[
+        ModifiedLine(
+            line='DEFAULT_ISSUE_REGEX = r"(?:refs?|closes?)[:\\s]*((?:#\\d+)|(?:#?[A-Z]+-\\d+))|(?:fix|feat|docs|style|refactor|perf|test|build|ci)\\((?:#(\\d+)|#?([A-Z]+-\\d+))\\)!?:"',
+            line_number=5,
+            relative_line_number=8,
+            modification_type="removed",
+            hunk_start_new=2,
+            hunk_start_old=2,
+        ),
+        ModifiedLine(
+            line='DEFAULT_ISSUE_REGEX = r"(?:refs?|closes?|resolves?)[:\\s]*((?:#\\d+)|(?:#?[A-Z]+-\\d+))|(?:fix|feat|docs|style|refactor|perf|test|build|ci)\\((?:#(\\d+)|#?([A-Z]+-\\d+))\\)!?:"',
+            line_number=5,
+            relative_line_number=9,
+            modification_type="added",
+            hunk_start_new=2,
+            hunk_start_old=2,
+        ),
+        ModifiedLine(
+            line="            pytest.param(",
+            line_number=206,
+            relative_line_number=18,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line="                PRMetadata(",
+            line_number=207,
+            relative_line_number=19,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line='                    title="fix: Bug fix for issue #456",',
+            line_number=208,
+            relative_line_number=20,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line='                    description="Resolves #456 and relates to PROJ-789.",',
+            line_number=209,
+            relative_line_number=21,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line="                ),",
+            line_number=210,
+            relative_line_number=22,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line='                "456",',
+            line_number=211,
+            relative_line_number=23,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line='                id="number-with-resolves-in-description",',
+            line_number=212,
+            relative_line_number=24,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+        ModifiedLine(
+            line="            ),",
+            line_number=213,
+            relative_line_number=25,
+            modification_type="added",
+            hunk_start_new=203,
+            hunk_start_old=203,
+        ),
+    ],
+)

--- a/tests/git_parser/test_parser.py
+++ b/tests/git_parser/test_parser.py
@@ -4,6 +4,8 @@ from lgtm_ai.git_parser.parser import DiffResult, parse_diff_patch
 from tests.git_parser.fixtures import (
     COMPLEX_DIFF_TEXT,
     DUMMY_METADATA,
+    GIT_SHOW,
+    PARSED_GIT_SHOW,
     PARSED_REFACTOR_DIFF,
     PARSED_SIMPLE_DIFF,
     REFACTOR_DIFF,
@@ -16,6 +18,7 @@ from tests.git_parser.fixtures import (
     [
         pytest.param(SIMPLE_DIFF, PARSED_SIMPLE_DIFF, id="simple"),
         pytest.param(REFACTOR_DIFF, PARSED_REFACTOR_DIFF, id="refactor"),
+        pytest.param(GIT_SHOW, PARSED_GIT_SHOW, id="git-show"),
     ],
 )
 def test_parse_diff_patch(input_diff: str, expected: DiffResult) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,14 +38,13 @@ def test_review_cli_gitlab(*args: mock.MagicMock) -> None:
     result = runner.invoke(
         review,
         [
-            "--pr-url",
-            "https://gitlab.com/user/repo/-/merge_requests/1",
             "--ai-api-key",
             "fake-token",
             "--git-api-key",
             "fake-token",
             "--ai-retries",
             "3",
+            "https://gitlab.com/user/repo/-/merge_requests/1",
         ],
     )
 
@@ -60,12 +59,11 @@ def test_review_cli_github(*args: mock.MagicMock) -> None:
     result = runner.invoke(
         review,
         [
-            "--pr-url",
-            "https://github.com/user/repo/pull/1",
             "--ai-api-key",
             "fake-token",
             "--git-api-key",
             "fake-token",
+            "https://github.com/user/repo/pull/1",
         ],
     )
 
@@ -80,14 +78,13 @@ def test_review_cli_with_custom_model(*args: mock.MagicMock) -> None:
     result = runner.invoke(
         review,
         [
-            "--pr-url",
-            "https://github.com/user/repo/pull/1",
             "--git-api-key",
             "fake-token",
             "--model",
             "alpaca",
             "--model-url",
             "http://localhost:1234",
+            "https://github.com/user/repo/pull/1",
         ],
     )
 
@@ -102,12 +99,11 @@ def test_guide_cli_gitlab(*args: mock.MagicMock) -> None:
     result = runner.invoke(
         guide,
         [
-            "--pr-url",
-            "https://gitlab.com/user/repo/-/merge_requests/1",
             "--ai-api-key",
             "fake-token",
             "--git-api-key",
             "fake-token",
+            "https://gitlab.com/user/repo/-/merge_requests/1",
         ],
     )
 
@@ -126,14 +122,13 @@ def test_enforce_model_url_for_unknown_model(cli_command: click.Command) -> None
     result = runner.invoke(
         cli_command,
         [
-            "--pr-url",
-            "https://gitlab.com/user/repo/-/merge_requests/1",
             "--model",
             "unknown-model",
             "--ai-api-key",
             "fake-token",
             "--git-api-key",
             "fake-token",
+            "https://gitlab.com/user/repo/-/merge_requests/1",
         ],
     )
 
@@ -169,14 +164,13 @@ def test_get_formatter_and_printer(output_format: str, expected_formatter: str, 
         result = runner.invoke(
             cli_command,
             [
-                "--pr-url",
-                "https://gitlab.com/user/repo/-/merge_requests/1",
                 "--ai-api-key",
                 "fake-token",
                 "--git-api-key",
                 "fake-token",
                 "--output-format",
                 output_format,
+                "https://gitlab.com/user/repo/-/merge_requests/1",
             ],
             catch_exceptions=False,
         )
@@ -211,8 +205,6 @@ def test_review_issues_correct_issues_client_according_to_cli(
         result = runner.invoke(
             review,
             [
-                "--pr-url",
-                "https://gitlab.com/user/repo/-/merge_requests/1",
                 "--ai-api-key",
                 "fake-token",
                 "--git-api-key",
@@ -222,6 +214,7 @@ def test_review_issues_correct_issues_client_according_to_cli(
                 "--issues-platform",
                 issues_platform.value,
                 *extra_cli_args,
+                "https://gitlab.com/user/repo/-/merge_requests/1",
             ],
             catch_exceptions=False,
         )


### PR DESCRIPTION
This PR will break most uses of lgtm.

Preparing for #22 , I decided to change the target of _what_ to review from an _option_ to an _argument_.

From [click docs](https://click.palletsprojects.com/en/stable/parameters/):

**Options**
- Are optional.
- Recommended to use for everything except subcommands, urls, or files.
- Can take a fixed number of arguments. The default is 1. 
- Are fully documented by the help page.
- Have automatic prompting for missing input.
- Can act as flags (boolean or otherwise).

**Arguments**
- Are optional with in reason, but not entirely so.
- Recommended to use for subcommands, urls, or files.
- Can take an arbitrary number of arguments.
- Are not fully documented by the help page since they may be too specific to be automatically documented. For more see [Documenting Arguments](https://click.palletsprojects.com/en/stable/documentation/#documenting-arguments).
- Can be pulled from environment variables but only explicitly named ones. For more see [Environment Variables](https://click.palletsprojects.com/en/stable/arguments/#environment-variables).


I think the "pr-url" and the future "git dir to review" fit more the definition of arguments. This also simplifies stuff, because we don't need to check for incompatible options etc.