### PR TITLE
fix: ensure guides can only run on remote PR URLs and not local repos

### DIFF
--- a/src/lgtm_ai/__main__.py
+++ b/src/lgtm_ai/__main__.py
@@ -245,7 +245,7 @@ def review(
 @entry_point.command()
 @_common_options
 def guide(
-    target: PRUrl,
+    target: PRUrl | LocalRepository,
     model: SupportedAIModels | None,
     model_url: str | None,
     git_api_key: str | None,
@@ -264,6 +264,9 @@ def guide(
     TARGET is the URL of the pull request to generate a guide for.
     """
     _set_logging_level(logger, verbose)
+    if isinstance(target, LocalRepository):
+        logger.error("Review guides can only be generated for Pull Request URLs, not local repositories.")
+        raise click.Abort()
 
     logger.info("lgtm-ai version: %s", __version__)
     logger.debug("Parsed PR URL: %s", target)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -145,6 +145,27 @@ def test_guide_cli_gitlab(*args: mock.MagicMock) -> None:
     assert result.exit_code == 0
 
 
+@mock.patch("lgtm_ai.__main__.ReviewGuideGenerator")
+@mock.patch("lgtm_ai.__main__.PrettyFormatter")
+@mock.patch("lgtm_ai.__main__.get_git_client")
+def test_guide_cli_local_fails(*args: mock.MagicMock) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        guide,
+        [
+            "--ai-api-key",
+            "fake-token",
+            "--git-api-key",
+            "fake-token",
+            ".",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Aborted!" in result.stderr
+
+
 @pytest.mark.parametrize(
     "cli_command",
     [


### PR DESCRIPTION
I don't think it makes sense to create a reviewer guide if there is no PR to review, so went with the easy option.

refs #22 