### PR TITLE
fix: defer git import to avoid errors if git is not installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ ENV PATH="/venv/bin:${PATH}"
 
 WORKDIR /app
 
+# Install git for reviewing local changes
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy virtualenv and source code from builder
 COPY --from=builder /venv /venv
 COPY . .

--- a/src/lgtm_ai/git/exceptions.py
+++ b/src/lgtm_ai/git/exceptions.py
@@ -2,3 +2,6 @@ from lgtm_ai.base.exceptions import LGTMException
 
 
 class GitDiffParseError(LGTMException): ...
+
+
+class GitNotFoundError(LGTMException): ...

--- a/tests/git/test_repository.py
+++ b/tests/git/test_repository.py
@@ -68,7 +68,7 @@ class TestGetDiffFromLocalRepo:
         with pytest.raises(GitDiffParseError, match="Cannot read local git repository"):
             get_diff_from_local_repo(invalid_path)
 
-    @mock.patch("lgtm_ai.git.repository.git.Repo")
+    @mock.patch("git.Repo")
     def test_working_directory_changes_default(self, mock_repo_class: mock.Mock) -> None:
         """Test default behavior - working directory changes vs HEAD."""
         mock_repo = mock.Mock()
@@ -83,7 +83,7 @@ class TestGetDiffFromLocalRepo:
         assert result.target_branch == "HEAD"
         assert result.source_branch == "main"
 
-    @mock.patch("lgtm_ai.git.repository.git.Repo")
+    @mock.patch("git.Repo")
     def test_compare_against_branch(self, mock_repo_class: mock.Mock) -> None:
         """Test comparing against a specific branch."""
         mock_repo = mock.Mock()
@@ -101,7 +101,7 @@ class TestGetDiffFromLocalRepo:
         assert result.target_branch == "main"
         assert result.source_branch == "feature"
 
-    @mock.patch("lgtm_ai.git.repository.git.Repo")
+    @mock.patch("git.Repo")
     def test_invalid_compare_reference(self, mock_repo_class: mock.Mock) -> None:
         """Test error handling for invalid branch/commit references."""
         mock_repo = mock.Mock()
@@ -111,7 +111,7 @@ class TestGetDiffFromLocalRepo:
         with pytest.raises(GitDiffParseError, match="Invalid branch/commit: invalid-ref"):
             get_diff_from_local_repo(pathlib.Path("/fake/path"), compare="invalid-ref")
 
-    @mock.patch("lgtm_ai.git.repository.git.Repo")
+    @mock.patch("git.Repo")
     @mock.patch("lgtm_ai.git.repository.parse_diff_patch")
     @mock.patch("lgtm_ai.git.repository._extract_file_metadata")
     @mock.patch("lgtm_ai.git.repository._get_diff_text")
@@ -159,7 +159,7 @@ class TestGetDiffFromLocalRepo:
             ("abc123", "abc123"),
         ],
     )
-    @mock.patch("lgtm_ai.git.repository.git.Repo")
+    @mock.patch("git.Repo")
     def test_compare_parameter_values(self, mock_repo_class: mock.Mock, compare: str, expected_target: str) -> None:
         """Test various values for the compare parameter."""
         mock_repo = mock.Mock()


### PR DESCRIPTION
If you `import git`, you actually check that the `git` executable is in `PATH`. This fails on the Docker image on CI (while it works on my machine, of course).

To reproduce locally:

```sh
PATH=./.venv/bin lgtm review --ai-api-key $NEW_GEMINI --model gemini-2.5-flash "https://gitlab.com/X/-/merge_requests/1" --git-api-key $GITLAB_TOKEN -vv
```

This produces this error:

```
Traceback (most recent call last):
  File "/venv/lib/python3.13/site-packages/git/__init__.py", line 296, in <module>
    refresh()
    ~~~~~~~^^
  File "/venv/lib/python3.13/site-packages/git/__init__.py", line 287, in refresh
    if not Git.refresh(path=path):
           ~~~~~~~~~~~^^^^^^^^^^^
  File "/venv/lib/python3.13/site-packages/git/cmd.py", line 860, in refresh
    raise ImportError(err)
ImportError: Bad git executable.
```


I also installed git in our docker image, in case one wants to review local changes with it.