### PR TITLE
fix: handling of target for guides, tests using lgtm.toml

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ venv := ".venv"
 bin := venv + "/bin"
 python_version := "python3.13"
 run := "poetry run"
-target_dirs := "src tests"
+target_dirs := "src tests scripts"
 image := "docker.io/elementsinteractive/lgtm-ai"
 
 # SENTINELS

--- a/lgtm.toml
+++ b/lgtm.toml
@@ -5,3 +5,7 @@ model = "gemini-2.5-pro"
 silent = false
 publish = true
 ai_retries = 2
+
+# GitHub issues integration
+issues_platform = "github"
+issues_url = "https://github.com/elementsinteractive/lgtm-ai/issues"

--- a/scripts/evaluate_review_quality.py
+++ b/scripts/evaluate_review_quality.py
@@ -15,7 +15,7 @@ from lgtm_ai.formatters.markdown import MarkDownFormatter
 from lgtm_ai.git_client.gitlab import GitlabClient
 from lgtm_ai.review import CodeReviewer
 from lgtm_ai.review.context import ContextRetriever
-from lgtm_ai.validators import parse_target
+from lgtm_ai.validators import _parse_target
 from rich.logging import RichHandler
 
 PRS_FOR_EVALUATION = {
@@ -94,7 +94,7 @@ def get_git_branch() -> str:
 def perform_review(
     output_dir: str, pr_url: str, pr_name: str, sample: int, model: SupportedAIModels, git_api_key: str, ai_api_key: str
 ) -> None:
-    url = parse_target(mock.Mock(), "pr_url", pr_url)
+    url = _parse_target(mock.Mock(), "pr_url", pr_url)
     git_client = GitlabClient(client=gitlab.Gitlab(private_token=git_api_key), formatter=MarkDownFormatter())
     code_reviewer = CodeReviewer(
         reviewer_agent=get_reviewer_agent_with_settings(),

--- a/scripts/evaluate_review_quality.py
+++ b/scripts/evaluate_review_quality.py
@@ -15,7 +15,7 @@ from lgtm_ai.formatters.markdown import MarkDownFormatter
 from lgtm_ai.git_client.gitlab import GitlabClient
 from lgtm_ai.review import CodeReviewer
 from lgtm_ai.review.context import ContextRetriever
-from lgtm_ai.validators import _parse_target
+from lgtm_ai.validators import TargetParser
 from rich.logging import RichHandler
 
 PRS_FOR_EVALUATION = {
@@ -94,7 +94,7 @@ def get_git_branch() -> str:
 def perform_review(
     output_dir: str, pr_url: str, pr_name: str, sample: int, model: SupportedAIModels, git_api_key: str, ai_api_key: str
 ) -> None:
-    url = _parse_target(mock.Mock(), "pr_url", pr_url)
+    url = TargetParser(allow_git_repo=True)(mock.Mock(), "pr_url", pr_url)
     git_client = GitlabClient(client=gitlab.Gitlab(private_token=git_api_key), formatter=MarkDownFormatter())
     code_reviewer = CodeReviewer(
         reviewer_agent=get_reviewer_agent_with_settings(),

--- a/src/lgtm_ai/__main__.py
+++ b/src/lgtm_ai/__main__.py
@@ -32,7 +32,7 @@ from lgtm_ai.review.guide import ReviewGuideGenerator
 from lgtm_ai.validators import (
     IntOrNoLimitType,
     ModelChoice,
-    parse_target,
+    TargetParser,
     validate_model_url,
 )
 from rich.console import Console
@@ -57,7 +57,6 @@ def entry_point() -> None:
 def _common_options[**P, T](func: Callable[P, T]) -> Callable[P, T]:
     """Wrap a click command and adds common options for lgtm commands."""
 
-    @click.argument("target", required=True, callback=parse_target)
     @click.option(
         "--model",
         type=ModelChoice(SupportedAIModelsList),
@@ -112,6 +111,7 @@ def _common_options[**P, T](func: Callable[P, T]) -> Callable[P, T]:
     return wrapper
 
 
+@click.argument("target", required=True, callback=TargetParser(allow_git_repo=True))
 @entry_point.command()
 @_common_options
 @click.option(
@@ -216,6 +216,7 @@ def review(target: PRUrl | LocalRepository, config: str | None, verbose: int, **
         logger.info("Review published successfully")
 
 
+@click.argument("target", required=True, callback=TargetParser(allow_git_repo=False))
 @entry_point.command()
 @_common_options
 def guide(

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -144,11 +143,3 @@ def clean_env_secrets() -> Iterator[None]:
         # Restore original environment
         os.environ.clear()
         os.environ.update(original_env)
-
-
-@pytest.fixture(autouse=True)
-def mock_current_working_directory(tmp_path: Path) -> Iterator[None]:
-    with mock.patch("lgtm_ai.config.handler.os.getcwd", return_value=str(tmp_path)):
-        # We still mock the current directory because this is a python project,
-        # and thus it has a pyproject.toml file that will be read during the test execution!
-        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,21 @@
+from collections.abc import Iterator
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_current_working_directory(tmp_path: Path) -> Iterator[None]:
+    """Mock the current working directory for config handling in all tests.
+
+    This is done so that the `lgtm.toml` file of `lgtm` is not used in tests.
+    """
+    with mock.patch("lgtm_ai.config.handler.os.getcwd", return_value=str(tmp_path)):
+        yield
 
 
 class CopyingMock(MagicMock):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from unittest import mock
 
 import click
@@ -73,7 +74,14 @@ def test_review_cli_github(*args: mock.MagicMock) -> None:
 @mock.patch("lgtm_ai.__main__.CodeReviewer")
 @mock.patch("lgtm_ai.__main__.PrettyFormatter")
 @mock.patch("lgtm_ai.__main__.get_git_client")
-def test_review_cli_local(*args: mock.MagicMock) -> None:
+def test_review_cli_local(
+    m_get_git_client: mock.MagicMock,
+    m_formatter: mock.MagicMock,
+    m_reviewer: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    # Create a .git directory to simulate a git repository
+    (tmp_path / ".git").mkdir()
     runner = CliRunner()
     result = runner.invoke(
         review,
@@ -90,14 +98,19 @@ def test_review_cli_local(*args: mock.MagicMock) -> None:
 @mock.patch("lgtm_ai.__main__.CodeReviewer")
 @mock.patch("lgtm_ai.__main__.PrettyFormatter")
 @mock.patch("lgtm_ai.__main__.get_git_client")
-def test_review_cli_local_does_not_exist(*args: mock.MagicMock) -> None:
+def test_review_cli_local_does_not_exist(
+    m_get_git_client: mock.MagicMock,
+    m_formatter: mock.MagicMock,
+    m_reviewer: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
     runner = CliRunner()
     result = runner.invoke(
         review,
         [
             "--ai-api-key",
             "fake-token",
-            "./foo/bar/baz",
+            "./fake",
         ],
         catch_exceptions=False,
     )
@@ -162,8 +175,8 @@ def test_guide_cli_local_fails(*args: mock.MagicMock) -> None:
         catch_exceptions=False,
     )
 
-    assert result.exit_code == 1
-    assert "Aborted!" in result.stderr
+    assert result.exit_code == 2
+    assert "Invalid value for 'TARGET': The PR URL must be a valid URL" in result.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR was originally just attempting to add issues integration to our lgtm action in the repo.

However, it uncovered that some tests were using the `lgtm.toml` file of the repo itself.

Fixing that (with a solution that was already used in part of the test suite), uncovered an issue in handling `TARGET` for reviewer guides: we were accepting git repositories as target, and so a good error message was not displayed to the user.

This PR fixes all these issues.