### PR TITLE
fix: don't exit with code 1 when there is nothing to review

### DIFF
--- a/scripts/evaluate_review_quality.py
+++ b/scripts/evaluate_review_quality.py
@@ -111,7 +111,7 @@ def perform_review(
             technologies=("Python", "Django", "FastAPI"),
         ),
     )
-    review = code_reviewer.review_pull_request(target=url)
+    review = code_reviewer.review(target=url)
     write_review_to_dir(model, output_dir, pr_name, sample, review)
 
 

--- a/src/lgtm_ai/formatters/base.py
+++ b/src/lgtm_ai/formatters/base.py
@@ -30,3 +30,9 @@ class Formatter(Protocol[_T]):
     def format_review_comment(self, comment: ReviewComment, *, with_footer: bool = True) -> _T: ...
 
     def format_guide(self, guide: ReviewGuide) -> _T: ...
+
+    def empty_review_message(self) -> str:
+        """Message to display when nothing was reviewed."""
+
+    def empty_guide_message(self) -> str:
+        """Message to display when no guide was generated."""

--- a/src/lgtm_ai/formatters/json.py
+++ b/src/lgtm_ai/formatters/json.py
@@ -1,3 +1,5 @@
+import json
+
 from lgtm_ai.ai.schemas import Review, ReviewComment, ReviewGuide
 from lgtm_ai.formatters.base import Formatter
 
@@ -26,3 +28,9 @@ class JsonFormatter(Formatter[str]):
     def format_guide(self, guide: ReviewGuide) -> str:
         """Format the review guide as JSON."""
         return guide.model_dump_json(indent=2, exclude={"pr_diff"})
+
+    def empty_review_message(self) -> str:
+        return json.dumps({"review_response": None, "metadata": None}, indent=2)
+
+    def empty_guide_message(self) -> str:
+        return json.dumps({"guide_response": None, "metadata": None}, indent=2)

--- a/src/lgtm_ai/formatters/markdown.py
+++ b/src/lgtm_ai/formatters/markdown.py
@@ -75,6 +75,12 @@ class MarkDownFormatter(Formatter[str]):
             metadata=metadata,
         )
 
+    def empty_review_message(self) -> str:
+        return "> ⚠️ No files to review (all files excluded by provided configuration)."
+
+    def empty_guide_message(self) -> str:
+        return "> ⚠️ No files to generate a guide for (all files excluded by provided configuration)."
+
     def _format_snippet(self, comment: ReviewComment) -> str:
         template = self._template_env.get_template(self.SNIPPET_TEMPLATE)
         return template.render(language=comment.programming_language.lower(), snippet=comment.quote_snippet)

--- a/src/lgtm_ai/formatters/pretty.py
+++ b/src/lgtm_ai/formatters/pretty.py
@@ -103,3 +103,9 @@ class PrettyFormatter(Formatter[Panel | Layout | Group]):
             *references,
         )
         return layout
+
+    def empty_review_message(self) -> str:
+        return "✔ No files to review (all files excluded by provided configuration)."
+
+    def empty_guide_message(self) -> str:
+        return "✔ No files to generate a guide for (all files excluded by provided configuration)."

--- a/src/lgtm_ai/git/parser.py
+++ b/src/lgtm_ai/git/parser.py
@@ -33,6 +33,7 @@ _HUNK_REGEX = re.compile(r"^@@ -(\d+),?\d* \+(\d+),?\d* @@")
 
 
 def parse_diff_patch(metadata: DiffFileMetadata, diff_text: object) -> DiffResult:
+    """Parse a unified diff patch and return the modified lines with their metadata."""
     if not isinstance(diff_text, str):
         raise GitDiffParseError("Diff text is not a string")
 

--- a/src/lgtm_ai/git_client/gitlab.py
+++ b/src/lgtm_ai/git_client/gitlab.py
@@ -230,7 +230,7 @@ class GitlabClient(GitClient):
             except gitlab.exceptions.GitlabError:
                 comment_create_success = False
                 logger.debug(
-                    "Failed to post the comment anywhere specific, it will go to general decription (hopefully)"
+                    "Failed to post the comment anywhere specific, it will go to general description (hopefully)"
                 )
 
         return comment_create_success

--- a/src/lgtm_ai/jira/jira.py
+++ b/src/lgtm_ai/jira/jira.py
@@ -17,6 +17,10 @@ class JiraIssuesClient:
         self._httpx_client = httpx_client
 
     def get_issue_content(self, issues_url: HttpUrl, issue_id: str) -> IssueContent | None:
+        """Fetch the content of an issue from the base URL of the issues page.
+
+        Returns None if the issue cannot be fetched or parsed.
+        """
         api_url = f"https://{issues_url.host}/rest/api/{self.API_VERSION}/issue/{issue_id}"
 
         try:

--- a/src/lgtm_ai/mcp/__main__.py
+++ b/src/lgtm_ai/mcp/__main__.py
@@ -45,7 +45,7 @@ def get_lgtm_review(
     compare: Annotated[
         str,
         Field(
-            description="What to compare. Defaults to 'HEAD', which will review uncommited changes. To compare against another branch, pass the branch name (e.g., `main`)."
+            description="What to compare. Defaults to 'HEAD', which will review uncommitted changes. To compare against another branch, pass the branch name (e.g., `main`)."
         ),
     ] = "HEAD",
 ) -> ReviewOutput:
@@ -77,7 +77,7 @@ def get_lgtm_review(
         git_client=None,
         config=resolved_config,
     )
-    review = code_reviewer.review_pull_request(target=target)
+    review = code_reviewer.review(target=target)
 
     return ReviewOutput.model_validate(review)
 

--- a/src/lgtm_ai/review/context.py
+++ b/src/lgtm_ai/review/context.py
@@ -16,7 +16,7 @@ from lgtm_ai.git_client.schemas import ContextBranch, IssueContent, PRDiff, PRMe
 from lgtm_ai.review.schemas import PRCodeContext
 from pydantic import HttpUrl
 
-logger = logging.getLogger("lgtm.ai")
+logger = logging.getLogger("lgtm")
 
 
 class IssuesClient(Protocol):

--- a/src/lgtm_ai/review/guide.py
+++ b/src/lgtm_ai/review/guide.py
@@ -13,7 +13,7 @@ from pydantic_ai import Agent
 from pydantic_ai.models import Model
 from pydantic_ai.usage import UsageLimits
 
-logger = logging.getLogger("lgtm.ai")
+logger = logging.getLogger("lgtm")
 
 
 class ReviewGuideGenerator:

--- a/src/lgtm_ai/review/reviewer.py
+++ b/src/lgtm_ai/review/reviewer.py
@@ -43,7 +43,6 @@ class CodeReviewer:
     - Return a Review object containing the PR diff, final review response, and metadata about the review process.
 
     Main workflow:
-    1. Call review_pull_request(target):
         - Fetch PR metadata and diff.
         - Gather code and additional context, and optionally issue context.
         - Generate a review prompt and run the reviewer agent for the initial review.
@@ -86,8 +85,8 @@ class CodeReviewer:
         self.config = config
         self.context_retriever = context_retriever
 
-    def review_pull_request(self, target: PRUrl | LocalRepository) -> Review:
-        """Peform a full review of the given pull request URL and return it."""
+    def review(self, target: PRUrl | LocalRepository) -> Review:
+        """Perform a full review of the given pull request URL or local git repository and return it."""
         total_usage = RunUsage()
         usage_limits = UsageLimits(input_tokens_limit=self.config.ai_input_tokens_limit)
 

--- a/tests/git_client/test_github.py
+++ b/tests/git_client/test_github.py
@@ -91,6 +91,12 @@ class MockFormatter(Formatter[str]):
     def format_guide(self, guide: ReviewGuide) -> str:
         return "guide section"
 
+    def empty_review_message(self) -> str:
+        return "No review"
+
+    def empty_guide_message(self) -> str:
+        return "No guide"
+
 
 def test_repo_not_found_error() -> None:
     m_client = mock.Mock()

--- a/tests/git_client/test_gitlab.py
+++ b/tests/git_client/test_gitlab.py
@@ -90,6 +90,12 @@ class MockFormatter(Formatter[str]):
     def format_guide(self, guide: ReviewGuide) -> str:
         return "guide section"
 
+    def empty_review_message(self) -> str:
+        return "No review"
+
+    def empty_guide_message(self) -> str:
+        return "No guide"
+
 
 def test_project_not_found_error() -> None:
     m_client = mock.Mock()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -49,7 +49,7 @@ async def test_lgtm_review_tool(temp_git_repo: Path) -> None:
     from lgtm_ai.mcp.__main__ import mcp
 
     async with Client(mcp) as client:
-        with mock.patch("lgtm_ai.review.CodeReviewer.review_pull_request", return_value=MOCK_REVIEW) as mock_review:
+        with mock.patch("lgtm_ai.review.CodeReviewer.review", return_value=MOCK_REVIEW) as mock_review:
             result = await client.call_tool("lgtm-review", {"repo_path": str(temp_git_repo)})
 
     assert mock_review.call_count == 1

--- a/tests/review/test_reviewer.py
+++ b/tests/review/test_reviewer.py
@@ -94,7 +94,7 @@ def test_get_review_from_url_valid(context_retriever: ContextRetriever) -> None:
                 ),
             ),
         )
-        review = code_reviewer.review_pull_request(
+        review = code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -195,7 +195,7 @@ def test_get_review_with_issue(context_retriever: ContextRetriever) -> None:
                 issues_url="https://gitlab.com/example/repo/-/issues/",
             ),
         )
-        review = code_reviewer.review_pull_request(
+        review = code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -274,7 +274,7 @@ def test_summarizing_message_in_review(context_retriever: ContextRetriever) -> N
             context_retriever=context_retriever,
             config=ResolvedConfig(ai_api_key="", git_api_key=""),
         )
-        code_reviewer.review_pull_request(
+        code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -326,7 +326,7 @@ def test_get_review_adds_technologies_to_prompt(context_retriever: ContextRetrie
             context_retriever=context_retriever,
             config=ResolvedConfig(ai_api_key="", git_api_key="", technologies=("COBOL", "FORTRAN", "ODIN")),
         )
-        review = code_reviewer.review_pull_request(
+        review = code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -360,7 +360,7 @@ def test_get_review_adds_categories_to_prompt(context_retriever: ContextRetrieve
             context_retriever=context_retriever,
             config=ResolvedConfig(ai_api_key="", git_api_key="", categories=("Correctness", "Quality")),
         )
-        review = code_reviewer.review_pull_request(
+        review = code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -392,7 +392,7 @@ def test_review_fails_if_all_files_are_excluded() -> None:
         config=ResolvedConfig(ai_api_key="", git_api_key="", exclude=("*.txt",)),  # we exclude all txt files
     )
     with pytest.raises(NothingToReviewError):
-        code_reviewer.review_pull_request(
+        code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -417,7 +417,7 @@ def test_file_is_excluded_from_prompt(context_retriever: ContextRetriever) -> No
             context_retriever=context_retriever,
             config=ResolvedConfig(ai_api_key="", git_api_key="", exclude=("file2.txt",)),
         )
-        review = code_reviewer.review_pull_request(
+        review = code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 
@@ -457,7 +457,7 @@ def test_errors_are_handled_on_reviewer_agent(raised_error: Exception, expected_
     )
 
     with pytest.raises(expected_error):
-        code_reviewer.review_pull_request(
+        code_reviewer.review(
             target=PRUrl(full_url="foo", base_url="foo", repo_path="foo", pr_number=1, source=PRSource.gitlab)
         )
 


### PR DESCRIPTION
It was surprising behavior, and some TT people complained to me (understandably).

This PR contains some additional cosmetic changes (docstrings and internal renames that don't matter).


<img width="578" height="49" alt="image" src="https://github.com/user-attachments/assets/a061913d-c0ad-481e-b79a-d49a7949bc46" />
